### PR TITLE
Personas Tests | Prepare integration | Identify broken multi entity/multi TX 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,16 +135,16 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/JelteF/derive_more?rev=1196b2dd7a366c06db621093884adbc379fc0f0a#1196b2dd7a366c06db621093884adbc379fc0f0a"
+version = "1.0.0"
+source = "git+https://github.com/JelteF/derive_more?rev=d7f5b9e94d024790682f6fc4dcca13941cce64c8#d7f5b9e94d024790682f6fc4dcca13941cce64c8"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/JelteF/derive_more?rev=1196b2dd7a366c06db621093884adbc379fc0f0a#1196b2dd7a366c06db621093884adbc379fc0f0a"
+version = "1.0.0"
+source = "git+https://github.com/JelteF/derive_more?rev=d7f5b9e94d024790682f6fc4dcca13941cce64c8#d7f5b9e94d024790682f6fc4dcca13941cce64c8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ edition = "2021"
 actix-rt = "2.10.0"
 async-trait = "0.1.80"
 derive-getters = "0.4.0"
-derive_more = { git = "https://github.com/JelteF/derive_more", rev = "1196b2dd7a366c06db621093884adbc379fc0f0a", features = [
+
+# 1.0.0
+derive_more = { git = "https://github.com/JelteF/derive_more", rev = "d7f5b9e94d024790682f6fc4dcca13941cce64c8", features = [
     "debug",
     "display",
     "from_str",
 ] }
+
 indexmap = "2.2.6"
 indexset = "0.4.0"
 itertools = "0.13.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 [![codecov](https://codecov.io/github/Sajjon/one-does-not-simply-sign/branch/main/graph/badge.svg?token=PTFupnAjyZ)](https://codecov.io/github/Sajjon/one-does-not-simply-sign)
 
-"Coordinators" for collecting and accumulating signatures and public keys from multiple `FactorSources` in one "session".
+"Coordinators" for collecting and accumulating signatures and public keys from multiple `FactorSources` in one "session" or one "process".
+
+This repo contains seperate solutions for both "processes" (signature collecting and public key collecting respectively), since it was too hard to make a generic solution. Why? Because of the nature of differences in input, for signing we have a HashMap as input, many transactions ID to be signed by many derivation paths, per factor source, whereas for public key derivation we only have derivation paths. This makes it hard to come up with a suitable generic "shape".

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [![codecov](https://codecov.io/github/Sajjon/one-does-not-simply-sign/branch/main/graph/badge.svg?token=PTFupnAjyZ)](https://codecov.io/github/Sajjon/one-does-not-simply-sign)
 
-Key Derivation and Signatures signing "collectors".
+"Coordinators" for collecting and accumulating signatures and public keys from multiple `FactorSources` in one "session".

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 [![codecov](https://codecov.io/github/Sajjon/one-does-not-simply-sign/branch/main/graph/badge.svg?token=PTFupnAjyZ)](https://codecov.io/github/Sajjon/one-does-not-simply-sign)
+
+Key Derivation and Signatures signing "collectors".

--- a/src/derivation/collector/keys_collector.rs
+++ b/src/derivation/collector/keys_collector.rs
@@ -110,7 +110,7 @@ impl KeysCollector {
         _ = self
             .derive_with_factors() // in decreasing "friction order"
             .await
-            .inspect_err(|e| eprintln!("Failed to use factor sources: {:?}", e));
+            .inspect_err(|e| eprintln!("Failed to use factor sources: {:#?}", e));
         self.state.into_inner().keyrings.into_inner().outcome()
     }
 }

--- a/src/derivation/collector/keys_collector.rs
+++ b/src/derivation/collector/keys_collector.rs
@@ -117,15 +117,21 @@ impl KeysCollector {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct KeyDerivationOutcome {
-    pub factors_by_source: IndexMap<FactorSourceID, IndexSet<FactorInstance>>,
+    pub factors_by_source:
+        IndexMap<FactorSourceID, IndexSet<HierarchicalDeterministicFactorInstance>>,
 }
 impl KeyDerivationOutcome {
-    pub fn new(factors_by_source: IndexMap<FactorSourceID, IndexSet<FactorInstance>>) -> Self {
+    pub fn new(
+        factors_by_source: IndexMap<
+            FactorSourceID,
+            IndexSet<HierarchicalDeterministicFactorInstance>,
+        >,
+    ) -> Self {
         Self { factors_by_source }
     }
 
     /// ALL factor instances derived by the KeysCollector
-    pub fn all_factors(&self) -> IndexSet<FactorInstance> {
+    pub fn all_factors(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.factors_by_source
             .clone()
             .into_iter()

--- a/src/derivation/collector/keys_collector_preprocessor.rs
+++ b/src/derivation/collector/keys_collector_preprocessor.rs
@@ -30,7 +30,7 @@ impl Keyring {
                     .derived
                     .borrow()
                     .iter()
-                    .any(|x| x.hd_public_key == f.hd_public_key)));
+                    .any(|x| x.public_key == f.public_key)));
 
         self.derived.borrow_mut().extend(response)
     }

--- a/src/derivation/collector/keys_collector_preprocessor.rs
+++ b/src/derivation/collector/keys_collector_preprocessor.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 pub struct Keyring {
     pub factor_source_id: FactorSourceID,
     pub paths: IndexSet<DerivationPath>,
-    derived: RefCell<IndexSet<FactorInstance>>,
+    derived: RefCell<IndexSet<HierarchicalDeterministicFactorInstance>>,
 }
 
 impl Keyring {
@@ -15,11 +15,14 @@ impl Keyring {
             derived: RefCell::new(IndexSet::new()),
         }
     }
-    pub fn factors(&self) -> IndexSet<FactorInstance> {
+    pub fn factors(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.derived.borrow().clone()
     }
 
-    pub(crate) fn process_response(&self, response: IndexSet<FactorInstance>) {
+    pub(crate) fn process_response(
+        &self,
+        response: IndexSet<HierarchicalDeterministicFactorInstance>,
+    ) {
         assert!(response
             .iter()
             .all(|f| f.factor_source_id == self.factor_source_id

--- a/src/derivation/collector/keys_collector_preprocessor.rs
+++ b/src/derivation/collector/keys_collector_preprocessor.rs
@@ -96,7 +96,7 @@ impl KeysCollectorPreprocessor {
     ) -> (Keyrings, IndexSet<FactorSourcesOfKind>) {
         let all_factor_sources_in_profile = all_factor_sources_in_profile
             .into_iter()
-            .map(|f| (f.id, f))
+            .map(|f| (f.factor_source_id(), f))
             .collect::<HashMap<FactorSourceID, FactorSource>>();
 
         let factor_sources_of_kind = sort_group_factors(

--- a/src/derivation/collector/used_derivation_indices.rs
+++ b/src/derivation/collector/used_derivation_indices.rs
@@ -9,7 +9,7 @@ pub struct CreateNextDerivationPathRequest {
     pub factor_source_id: FactorSourceID,
     pub network_id: NetworkID,
     pub key_kind: CAP26KeyKind,
-    pub entity_kind: EntityKind,
+    pub entity_kind: CAP26EntityKind,
     pub key_space: KeySpace,
 }
 
@@ -18,7 +18,7 @@ impl CreateNextDerivationPathRequest {
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
         key_kind: CAP26KeyKind,
-        entity_kind: EntityKind,
+        entity_kind: CAP26EntityKind,
         key_space: KeySpace,
     ) -> Self {
         Self {
@@ -42,7 +42,7 @@ pub trait UsedDerivationIndices {
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
         key_kind: CAP26KeyKind,
-        entity_kind: EntityKind,
+        entity_kind: CAP26EntityKind,
         key_space: KeySpace,
     ) -> DerivationIndex {
         let request = CreateNextDerivationPathRequest::new(
@@ -60,7 +60,7 @@ pub trait UsedDerivationIndices {
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
         key_kind: CAP26KeyKind,
-        entity_kind: EntityKind,
+        entity_kind: CAP26EntityKind,
         key_space: KeySpace,
     ) -> DerivationPath {
         let index = self.next_derivation_index_for(

--- a/src/derivation/collector/used_derivation_indices.rs
+++ b/src/derivation/collector/used_derivation_indices.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 pub struct CreateNextDerivationPathRequest {
     pub factor_source_id: FactorSourceID,
     pub network_id: NetworkID,
-    pub key_kind: KeyKind,
+    pub key_kind: CAP26KeyKind,
     pub entity_kind: EntityKind,
     pub key_space: KeySpace,
 }
@@ -17,7 +17,7 @@ impl CreateNextDerivationPathRequest {
     pub fn new(
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
-        key_kind: KeyKind,
+        key_kind: CAP26KeyKind,
         entity_kind: EntityKind,
         key_space: KeySpace,
     ) -> Self {
@@ -41,7 +41,7 @@ pub trait UsedDerivationIndices {
         &self,
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
-        key_kind: KeyKind,
+        key_kind: CAP26KeyKind,
         entity_kind: EntityKind,
         key_space: KeySpace,
     ) -> DerivationIndex {
@@ -59,7 +59,7 @@ pub trait UsedDerivationIndices {
         &self,
         factor_source_id: FactorSourceID,
         network_id: NetworkID,
-        key_kind: KeyKind,
+        key_kind: CAP26KeyKind,
         entity_kind: EntityKind,
         key_space: KeySpace,
     ) -> DerivationPath {

--- a/src/derivation/interactors/keys_collecting_client.rs
+++ b/src/derivation/interactors/keys_collecting_client.rs
@@ -18,7 +18,10 @@ impl KeysCollectingClient {
             KeyDerivationInteractor::Parallel(interactor) => {
                 // Prepare the request for the interactor
                 let request = collector.request_for_parallel_interactor(
-                    factor_sources.into_iter().map(|f| f.id).collect(),
+                    factor_sources
+                        .into_iter()
+                        .map(|f| f.factor_source_id())
+                        .collect(),
                 );
                 let response = interactor.derive(request).await?;
                 collector.process_batch_response(response);
@@ -27,7 +30,8 @@ impl KeysCollectingClient {
             KeyDerivationInteractor::Serial(interactor) => {
                 for factor_source in factor_sources {
                     // Prepare the request for the interactor
-                    let request = collector.request_for_serial_interactor(&factor_source.id);
+                    let request =
+                        collector.request_for_serial_interactor(&factor_source.factor_source_id());
 
                     // Produce the results from the interactor
                     let response = interactor.derive(request).await?;

--- a/src/derivation/interactors/keys_collecting_interactors.rs
+++ b/src/derivation/interactors/keys_collecting_interactors.rs
@@ -52,10 +52,16 @@ impl SerialBatchKeyDerivationRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BatchDerivationResponse {
-    pub per_factor_source: IndexMap<FactorSourceID, IndexSet<FactorInstance>>,
+    pub per_factor_source:
+        IndexMap<FactorSourceID, IndexSet<HierarchicalDeterministicFactorInstance>>,
 }
 impl BatchDerivationResponse {
-    pub fn new(per_factor_source: IndexMap<FactorSourceID, IndexSet<FactorInstance>>) -> Self {
+    pub fn new(
+        per_factor_source: IndexMap<
+            FactorSourceID,
+            IndexSet<HierarchicalDeterministicFactorInstance>,
+        >,
+    ) -> Self {
         Self { per_factor_source }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
+#![feature(iter_repeat_n)]
 
 mod derivation;
 mod signing;

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -57,11 +57,9 @@ impl SignaturesCollector {
             .map(extract_signers)
             .collect::<Result<IndexSet<TXToSign>>>()?;
 
-        Ok(Self::with(
-            all_factor_sources_in_profile,
-            transactions,
-            interactors,
-        ))
+        let collector = Self::with(all_factor_sources_in_profile, transactions, interactors);
+
+        Ok(collector)
     }
 
     pub fn new(
@@ -267,6 +265,30 @@ mod tests {
     use std::iter;
 
     use super::*;
+
+    #[test]
+    fn invalid_profile_unknown_account() {
+        let res = SignaturesCollector::new(
+            IndexSet::from_iter([TransactionIntent::new([Account::a0().entity_address()], [])]),
+            Arc::new(TestSignatureCollectingInteractors::new(
+                SimulatedUser::prudent_no_fail(),
+            )),
+            &Profile::new(IndexSet::new(), [], []),
+        );
+        assert!(matches!(res, Err(CommonError::UnknownAccount)));
+    }
+
+    #[test]
+    fn invalid_profile_unknown_persona() {
+        let res = SignaturesCollector::new(
+            IndexSet::from_iter([TransactionIntent::new([], [Persona::p0().entity_address()])]),
+            Arc::new(TestSignatureCollectingInteractors::new(
+                SimulatedUser::prudent_no_fail(),
+            )),
+            &Profile::new(IndexSet::new(), [], []),
+        );
+        assert!(matches!(res, Err(CommonError::UnknownPersona)));
+    }
 
     #[test]
     fn test_profile() {

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -290,6 +290,22 @@ mod tests {
         assert!(matches!(res, Err(CommonError::UnknownPersona)));
     }
 
+    #[actix_rt::test]
+    async fn valid_profile() {
+        let factors_sources = FactorSource::all();
+        let persona = Persona::p0();
+        let collector = SignaturesCollector::new(
+            IndexSet::from_iter([TransactionIntent::new([], [persona.entity_address()])]),
+            Arc::new(TestSignatureCollectingInteractors::new(
+                SimulatedUser::prudent_no_fail(),
+            )),
+            &Profile::new(factors_sources, [], [&persona]),
+        )
+        .unwrap();
+        let outcome = collector.collect_signatures().await;
+        assert!(outcome.successful())
+    }
+
     #[test]
     fn test_profile() {
         let factor_sources = &FactorSource::all();

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -65,13 +65,12 @@ impl SignaturesCollector {
     }
 
     pub fn new(
-        all_factor_sources_in_profile: IndexSet<FactorSource>,
         transactions: IndexSet<TransactionIntent>,
         interactors: Arc<dyn SignatureCollectingInteractors>,
         profile: &Profile,
     ) -> Result<Self> {
         Self::with_signers_extraction(
-            all_factor_sources_in_profile,
+            profile.factor_sources.clone(),
             transactions,
             interactors,
             |i| TXToSign::extracting_from_intent_and_profile(&i, profile),

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -155,6 +155,8 @@ impl SignaturesCollector {
     async fn sign_with_factors(&self) -> Result<()> {
         let factors_of_kind = self.dependencies.factors_of_kind.clone();
         for factor_sources_of_kind in factors_of_kind.into_iter() {
+            println!("🔮 state: {:#?}", &self.state.borrow());
+
             self.sign_with_factors_of_kind(factor_sources_of_kind)
                 .await?;
 
@@ -245,7 +247,7 @@ impl SignaturesCollector {
         _ = self
             .sign_with_factors() // in decreasing "friction order"
             .await
-            .inspect_err(|e| eprintln!("Failed to use factor sources: {:?}", e));
+            .inspect_err(|e| eprintln!("Failed to use factor sources: {:#?}", e));
         self.state.into_inner().petitions.into_inner().outcome()
     }
 }

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -24,9 +24,9 @@ pub struct SignaturesCollector {
 }
 
 impl SignaturesCollector {
-    pub fn new(
+    fn with(
         all_factor_sources_in_profile: IndexSet<FactorSource>,
-        transactions: IndexSet<TransactionIntent>,
+        transactions: IndexSet<TXToSign>,
         interactors: Arc<dyn SignatureCollectingInteractors>,
     ) -> Self {
         let preprocessor = SignaturesCollectorPreprocessor::new(transactions);
@@ -39,6 +39,18 @@ impl SignaturesCollector {
             dependencies,
             state: RefCell::new(state),
         }
+    }
+
+    pub fn new<F>(
+        all_factor_sources_in_profile: IndexSet<FactorSource>,
+        transactions: IndexSet<TransactionIntent>,
+        interactors: Arc<dyn SignatureCollectingInteractors>,
+        extract_signers: F,
+    ) -> Self
+    where
+        F: Fn(TransactionIntent) -> TXToSign,
+    {
+        todo!()
     }
 }
 

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -83,6 +83,7 @@ impl TXToSign {
         intent: &TransactionIntent,
         profile: &Profile,
     ) -> Result<Self> {
+        let intent_hash = intent.intent_hash.clone();
         let summary = intent.manifest_summary();
         let mut entities_requiring_auth: IndexSet<AccountOrPersona> = IndexSet::new();
 
@@ -112,7 +113,7 @@ impl TXToSign {
                 .collect_vec(),
         );
 
-        Ok(Self::new(entities_requiring_auth))
+        Ok(Self::with(intent_hash, entities_requiring_auth))
     }
 }
 
@@ -249,5 +250,221 @@ impl SignaturesCollector {
             .await
             .inspect_err(|e| eprintln!("Failed to use factor sources: {:#?}", e));
         self.state.into_inner().petitions.into_inner().outcome()
+    }
+}
+
+#[cfg(test)]
+impl SignaturesCollector {
+    /// Used by tests
+    pub(crate) fn petitions(self) -> Petitions {
+        self.state.into_inner().petitions.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::iter;
+
+    use super::*;
+
+    #[test]
+    fn test_profile() {
+        let factor_sources = &FactorSource::all();
+        let a0 = &Account::a0();
+        let a1 = &Account::a1();
+        let a2 = &Account::a2();
+        let a6 = &Account::a6();
+
+        let p0 = &Persona::p0();
+        let p1 = &Persona::p1();
+        let p2 = &Persona::p2();
+        let p6 = &Persona::p6();
+
+        let t0 = TransactionIntent::address_of([a0, a1], [p0, p1]);
+        let t1 = TransactionIntent::address_of([a0, a1, a2], []);
+        let t2 = TransactionIntent::address_of([], [p0, p1, p2]);
+        let t3 = TransactionIntent::address_of([a6], [p6]);
+
+        let profile = Profile::new(factor_sources.clone(), [a0, a1, a2, a6], [p0, p1, p2, p6]);
+
+        let collector = SignaturesCollector::new(
+            IndexSet::<TransactionIntent>::from_iter([
+                t0.clone(),
+                t1.clone(),
+                t2.clone(),
+                t3.clone(),
+            ]),
+            Arc::new(TestSignatureCollectingInteractors::new(
+                SimulatedUser::prudent_no_fail(),
+            )),
+            &profile,
+        )
+        .unwrap();
+
+        let petitions = collector.petitions();
+
+        assert_eq!(petitions.txid_to_petition.borrow().len(), 4);
+
+        {
+            let petitions_ref = petitions.txid_to_petition.borrow();
+            let petition = petitions_ref.get(&t3.intent_hash).unwrap();
+            let for_entities = petition.for_entities.borrow().clone();
+            let pet6 = for_entities.get(&a6.address()).unwrap();
+
+            let paths6 = pet6
+                .all_factor_instances()
+                .iter()
+                .map(|f| f.factor_instance().derivation_path())
+                .collect_vec();
+
+            pretty_assertions::assert_eq!(
+                paths6,
+                iter::repeat_n(
+                    DerivationPath::new(
+                        NetworkID::Mainnet,
+                        CAP26EntityKind::Account,
+                        CAP26KeyKind::T9n,
+                        6
+                    ),
+                    5
+                )
+                .collect_vec()
+            );
+        }
+
+        let assert_petition = |t: &TransactionIntent,
+                               threshold_factors: HashMap<
+            AddressOfAccountOrPersona,
+            HashSet<FactorSourceID>,
+        >,
+                               override_factors: HashMap<
+            AddressOfAccountOrPersona,
+            HashSet<FactorSourceID>,
+        >| {
+            let petitions_ref = petitions.txid_to_petition.borrow();
+            let petition = petitions_ref.get(&t.intent_hash).unwrap();
+            assert_eq!(petition.intent_hash, t.intent_hash);
+
+            let mut addresses = threshold_factors.keys().collect::<HashSet<_>>();
+            addresses.extend(override_factors.keys().collect::<HashSet<_>>());
+
+            assert_eq!(
+                petition
+                    .for_entities
+                    .borrow()
+                    .keys()
+                    .collect::<HashSet<_>>(),
+                addresses
+            );
+
+            assert!(petition
+                .for_entities
+                .borrow()
+                .iter()
+                .all(|(a, p)| { p.entity == *a }));
+
+            assert!(petition
+                .for_entities
+                .borrow()
+                .iter()
+                .all(|(_, p)| { p.intent_hash == t.intent_hash }));
+
+            for (k, v) in petition.for_entities.borrow().iter() {
+                let threshold = threshold_factors.get(k);
+                if let Some(actual_threshold) = &v.threshold_factors {
+                    let threshold = threshold.unwrap().clone();
+                    assert_eq!(
+                        actual_threshold
+                            .borrow()
+                            .factor_instances()
+                            .into_iter()
+                            .map(|f| f.factor_source_id)
+                            .collect::<HashSet<_>>(),
+                        threshold
+                    );
+                } else {
+                    assert!(threshold.is_none());
+                }
+
+                let override_ = override_factors.get(k);
+                if let Some(actual_override) = &v.override_factors {
+                    let override_ = override_.unwrap().clone();
+                    assert_eq!(
+                        actual_override
+                            .borrow()
+                            .factor_instances()
+                            .into_iter()
+                            .map(|f| f.factor_source_id)
+                            .collect::<HashSet<_>>(),
+                        override_
+                    );
+                } else {
+                    assert!(override_.is_none());
+                }
+            }
+        };
+        assert_petition(
+            &t0,
+            HashMap::from_iter([
+                (a0.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+                (a1.address(), HashSet::from_iter([FactorSourceID::fs1()])),
+                (p0.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+                (p1.address(), HashSet::from_iter([FactorSourceID::fs1()])),
+            ]),
+            HashMap::new(),
+        );
+
+        assert_petition(
+            &t1,
+            HashMap::from_iter([
+                (a0.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+                (a1.address(), HashSet::from_iter([FactorSourceID::fs1()])),
+                (a2.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+            ]),
+            HashMap::new(),
+        );
+
+        assert_petition(
+            &t2,
+            HashMap::from_iter([
+                (p0.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+                (p1.address(), HashSet::from_iter([FactorSourceID::fs1()])),
+                (p2.address(), HashSet::from_iter([FactorSourceID::fs0()])),
+            ]),
+            HashMap::new(),
+        );
+
+        assert_petition(
+            &t3,
+            HashMap::from_iter([
+                (
+                    a6.address(),
+                    HashSet::from_iter([
+                        FactorSourceID::fs0(),
+                        FactorSourceID::fs3(),
+                        FactorSourceID::fs5(),
+                    ]),
+                ),
+                (
+                    p6.address(),
+                    HashSet::from_iter([
+                        FactorSourceID::fs0(),
+                        FactorSourceID::fs3(),
+                        FactorSourceID::fs5(),
+                    ]),
+                ),
+            ]),
+            HashMap::from_iter([
+                (
+                    a6.address(),
+                    HashSet::from_iter([FactorSourceID::fs1(), FactorSourceID::fs4()]),
+                ),
+                (
+                    p6.address(),
+                    HashSet::from_iter([FactorSourceID::fs1(), FactorSourceID::fs4()]),
+                ),
+            ]),
+        );
     }
 }

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 pub struct SignaturesCollectorPreprocessor {
-    transactions: IndexSet<TransactionIntent>,
+    transactions: IndexSet<TXToSign>,
 }
 
 pub fn sort_group_factors(
@@ -26,7 +26,7 @@ pub fn sort_group_factors(
 }
 
 impl SignaturesCollectorPreprocessor {
-    pub(super) fn new(transactions: IndexSet<TransactionIntent>) -> Self {
+    pub(super) fn new(transactions: IndexSet<TXToSign>) -> Self {
         Self { transactions }
     }
 

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -67,7 +67,7 @@ impl SignaturesCollectorPreprocessor {
             let mut petitions_for_entities =
                 HashMap::<AddressOfAccountOrPersona, PetitionEntity>::new();
 
-            for entity in transaction.clone().entities_requiring_auth {
+            for entity in transaction.entities_requiring_auth() {
                 let address = entity.address();
                 match entity.security_state() {
                     EntitySecurityState::Securified(sec) => {

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -65,11 +65,11 @@ impl SignaturesCollectorPreprocessor {
 
         for transaction in transactions.into_iter() {
             let mut petitions_for_entities =
-                HashMap::<AccountAddressOrIdentityAddress, PetitionEntity>::new();
+                HashMap::<AddressOfAccountOrPersona, PetitionEntity>::new();
 
             for entity in transaction.clone().entities_requiring_auth {
-                let address = entity.address;
-                match entity.security_state {
+                let address = entity.address();
+                match entity.security_state() {
                     EntitySecurityState::Securified(sec) => {
                         let primary_role_matrix = sec;
 

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -73,7 +73,7 @@ impl SignaturesCollectorPreprocessor {
                     EntitySecurityState::Securified(sec) => {
                         let primary_role_matrix = sec;
 
-                        let mut add = |factors: Vec<FactorInstance>| {
+                        let mut add = |factors: Vec<HierarchicalDeterministicFactorInstance>| {
                             factors.into_iter().for_each(|f| {
                                 let factor_source_id = f.factor_source_id;
                                 use_factor_in_tx(&factor_source_id, &transaction.intent_hash);

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -9,7 +9,7 @@ pub fn sort_group_factors(
 ) -> IndexSet<FactorSourcesOfKind> {
     let factors_of_kind = used_factor_sources
         .into_iter()
-        .into_grouping_map_by(|x| x.kind())
+        .into_grouping_map_by(|x| x.factor_source_kind())
         .collect::<IndexSet<FactorSource>>();
 
     let mut factors_of_kind = factors_of_kind

--- a/src/signing/collector/signatures_collector_preprocessor.rs
+++ b/src/signing/collector/signatures_collector_preprocessor.rs
@@ -39,7 +39,7 @@ impl SignaturesCollectorPreprocessor {
 
         let all_factor_sources_in_profile = all_factor_sources_in_profile
             .into_iter()
-            .map(|f| (f.id, f))
+            .map(|f| (f.factor_source_id(), f))
             .collect::<HashMap<FactorSourceID, FactorSource>>();
 
         let mut factor_to_payloads = HashMap::<FactorSourceID, IndexSet<IntentHash>>::new();

--- a/src/signing/collector/signatures_collector_state.rs
+++ b/src/signing/collector/signatures_collector_state.rs
@@ -1,11 +1,12 @@
 use crate::prelude::*;
 
+#[derive(derive_more::Debug)]
+#[debug("{:#?}", petitions.borrow())]
 pub(super) struct SignaturesCollectorState {
     pub(super) petitions: RefCell<Petitions>,
 }
 impl SignaturesCollectorState {
     pub fn new(petitions: Petitions) -> Self {
-        println!("petitions: {:?}", &petitions);
         Self {
             petitions: RefCell::new(petitions),
         }

--- a/src/signing/collector/signatures_collector_state.rs
+++ b/src/signing/collector/signatures_collector_state.rs
@@ -5,6 +5,7 @@ pub(super) struct SignaturesCollectorState {
 }
 impl SignaturesCollectorState {
     pub fn new(petitions: Petitions) -> Self {
+        println!("petitions: {:?}", &petitions);
         Self {
             petitions: RefCell::new(petitions),
         }

--- a/src/signing/interactors/batch_signing_response.rs
+++ b/src/signing/interactors/batch_signing_response.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 /// enough keys (derivation paths) needed for it to be valid when submitted to the
 /// Radix network.
 #[derive(Clone, PartialEq, Eq, derive_more::Debug)]
-#[debug("BatchSigningResponse {{ signatures: {:?} }}", signatures.values().map(|f| format!("{:?}", f)).join(", "))]
+#[debug("BatchSigningResponse {{ signatures: {:#?} }}", signatures.values().map(|f| format!("{:#?}", f)).join(", "))]
 pub struct BatchSigningResponse {
     pub signatures: IndexMap<FactorSourceID, IndexSet<HDSignature>>,
 }

--- a/src/signing/interactors/sign_with_factor_client.rs
+++ b/src/signing/interactors/sign_with_factor_client.rs
@@ -19,7 +19,10 @@ impl SignWithFactorClient {
             SigningInteractor::Parallel(interactor) => {
                 // Prepare the request for the interactor
                 let request = collector.request_for_parallel_interactor(
-                    factor_sources.into_iter().map(|f| f.id).collect(),
+                    factor_sources
+                        .into_iter()
+                        .map(|f| f.factor_source_id())
+                        .collect(),
                 );
                 let response = interactor.sign(request).await?;
                 collector.process_batch_response(response);
@@ -32,7 +35,8 @@ impl SignWithFactorClient {
             SigningInteractor::Serial(interactor) => {
                 for factor_source in factor_sources {
                     // Prepare the request for the interactor
-                    let request = collector.request_for_serial_interactor(&factor_source.id);
+                    let request =
+                        collector.request_for_serial_interactor(&factor_source.factor_source_id());
 
                     // Produce the results from the interactor
                     let response = interactor.sign(request).await?;

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -2,8 +2,10 @@ mod collector;
 mod interactors;
 mod petition_types;
 mod signatures_outcome_types;
+mod tx_to_sign;
 
 pub use collector::*;
 pub use interactors::*;
 pub use petition_types::*;
 pub use signatures_outcome_types::*;
+pub use tx_to_sign::*;

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -262,26 +262,26 @@ impl PetitionEntity {
 }
 
 impl PetitionEntity {
-    fn from_entity(entity: AccountOrPersona, intent_hash: IntentHash) -> Self {
-        match entity.security_state {
+    fn from_entity(entity: impl Into<AccountOrPersona>, intent_hash: IntentHash) -> Self {
+        let entity = entity.into();
+        match entity.security_state() {
             EntitySecurityState::Securified(matrix) => {
-                Self::new_securified(intent_hash, entity.address, matrix)
+                Self::new_securified(intent_hash, entity.address(), matrix)
             }
             EntitySecurityState::Unsecured(factor) => {
-                Self::new_unsecurified(intent_hash, entity.address, factor)
+                Self::new_unsecurified(intent_hash, entity.address(), factor)
             }
         }
     }
 }
+
 impl HasSampleValues for PetitionEntity {
     fn sample() -> Self {
-        Self::from_entity(AccountOrPersona::sample_securified(), IntentHash::sample())
+        Self::from_entity(Account::sample_securified(), IntentHash::sample())
     }
+
     fn sample_other() -> Self {
-        Self::from_entity(
-            AccountOrPersona::sample_unsecurified(),
-            IntentHash::sample_other(),
-        )
+        Self::from_entity(Account::sample_unsecurified(), IntentHash::sample_other())
     }
 }
 
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "A factor MUST NOT be present in both threshold AND override list.")]
     fn factor_should_not_be_used_in_both_lists() {
-        AccountOrPersona::securified_mainnet(0, "Jane Doe", |idx| {
+        Account::securified_mainnet(0, "Jane Doe", |idx| {
             let fi = FactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
@@ -325,7 +325,7 @@ mod tests {
     #[should_panic]
     fn cannot_add_same_signature_twice() {
         let intent_hash = IntentHash::sample();
-        let entity = AccountOrPersona::securified_mainnet(0, "Jane Doe", |idx| {
+        let entity = Account::securified_mainnet(0, "Jane Doe", |idx| {
             let fi = FactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
@@ -337,7 +337,7 @@ mod tests {
         let sign_input = HDSignatureInput::new(
             intent_hash,
             OwnedFactorInstance::new(
-                entity.address.clone(),
+                entity.address(),
                 FactorInstance::account_mainnet_tx(0, FactorSourceID::fs0()),
             ),
         );

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -3,7 +3,8 @@ use crate::prelude::*;
 /// Petition of signatures from an entity in a transaction.
 /// Essentially a wrapper around a tuple
 /// `{ threshold: PetitionFactors, override: PetitionFactors }`
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub struct PetitionEntity {
     /// The owner of these factors
     pub entity: AddressOfAccountOrPersona,
@@ -19,6 +20,22 @@ pub struct PetitionEntity {
 }
 
 impl PetitionEntity {
+    fn debug_str(&self) -> String {
+        format!(
+            "intent_hash: {:?}, entity: {:?}, {:?}{:?}",
+            self.intent_hash,
+            self.entity,
+            self.threshold_factors
+                .clone()
+                .map(|f| format!("threshold_factors {:?}", f.borrow()))
+                .or(Some(String::new())),
+            self.override_factors
+                .clone()
+                .map(|f| format!("override_factors {:?}", f.borrow()))
+                .or(Some(String::new()))
+        )
+    }
+
     pub fn new(
         intent_hash: IntentHash,
         entity: AddressOfAccountOrPersona,

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -308,7 +308,7 @@ mod tests {
     #[should_panic(expected = "A factor MUST NOT be present in both threshold AND override list.")]
     fn factor_should_not_be_used_in_both_lists() {
         Account::securified_mainnet(0, "Jane Doe", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(CAP26EntityKind::Account, idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
                 1,
@@ -322,7 +322,7 @@ mod tests {
     fn cannot_add_same_signature_twice() {
         let intent_hash = IntentHash::sample();
         let entity = Account::securified_mainnet(0, "Jane Doe", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(CAP26EntityKind::Account, idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
                 1,

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -21,18 +21,23 @@ pub struct PetitionEntity {
 
 impl PetitionEntity {
     fn debug_str(&self) -> String {
+        let thres: String = self
+            .threshold_factors
+            .clone()
+            .map(|f| format!("threshold_factors {:#?}", f.borrow()))
+            .or(Some(String::new()))
+            .unwrap();
+
+        let overr: String = self
+            .override_factors
+            .clone()
+            .map(|f| format!("override_factors {:#?}", f.borrow()))
+            .or(Some(String::new()))
+            .unwrap();
+
         format!(
-            "intent_hash: {:?}, entity: {:?}, {:?}{:?}",
-            self.intent_hash,
-            self.entity,
-            self.threshold_factors
-                .clone()
-                .map(|f| format!("threshold_factors {:?}", f.borrow()))
-                .or(Some(String::new())),
-            self.override_factors
-                .clone()
-                .map(|f| format!("override_factors {:?}", f.borrow()))
-                .or(Some(String::new()))
+            "intent_hash: {:#?}, entity: {:#?}, {:#?}{:#?}",
+            self.intent_hash, self.entity, thres, overr
         )
     }
 

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -54,7 +54,7 @@ impl PetitionEntity {
     pub fn new_unsecurified(
         intent_hash: IntentHash,
         entity: AddressOfAccountOrPersona,
-        instance: FactorInstance,
+        instance: HierarchicalDeterministicFactorInstance,
     ) -> Self {
         Self::new(
             intent_hash,
@@ -93,7 +93,7 @@ impl PetitionEntity {
             .collect::<IndexSet<_>>()
     }
 
-    pub fn all_skipped_factor_instance(&self) -> IndexSet<FactorInstance> {
+    pub fn all_skipped_factor_instance(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.union_of(|f| f.all_skipped())
     }
 
@@ -312,7 +312,7 @@ mod tests {
     #[should_panic(expected = "A factor MUST NOT be present in both threshold AND override list.")]
     fn factor_should_not_be_used_in_both_lists() {
         Account::securified_mainnet(0, "Jane Doe", |idx| {
-            let fi = FactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
                 1,
@@ -326,7 +326,7 @@ mod tests {
     fn cannot_add_same_signature_twice() {
         let intent_hash = IntentHash::sample();
         let entity = Account::securified_mainnet(0, "Jane Doe", |idx| {
-            let fi = FactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
                 1,
@@ -338,7 +338,10 @@ mod tests {
             intent_hash,
             OwnedFactorInstance::new(
                 entity.address(),
-                FactorInstance::account_mainnet_tx(0, FactorSourceID::fs0()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    0,
+                    FactorSourceID::fs0(),
+                ),
             ),
         );
         let signature = HDSignature::produced_signing_with_input(sign_input);
@@ -355,7 +358,10 @@ mod tests {
                 sut.intent_hash.clone(),
                 OwnedFactorInstance::new(
                     sut.entity.clone(),
-                    FactorInstance::account_mainnet_tx(6, FactorSourceID::fs1()),
+                    HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                        6,
+                        FactorSourceID::fs1(),
+                    ),
                 ),
             ),
         ));

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -20,20 +20,19 @@ pub struct PetitionEntity {
 }
 
 impl PetitionEntity {
+    #[allow(unused)]
     fn debug_str(&self) -> String {
         let thres: String = self
             .threshold_factors
             .clone()
             .map(|f| format!("threshold_factors {:#?}", f.borrow()))
-            .or(Some(String::new()))
-            .unwrap();
+            .unwrap_or_default();
 
         let overr: String = self
             .override_factors
             .clone()
             .map(|f| format!("override_factors {:#?}", f.borrow()))
-            .or(Some(String::new()))
-            .unwrap();
+            .unwrap_or_default();
 
         format!(
             "intent_hash: {:#?}, entity: {:#?}, {:#?}{:#?}",

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PetitionEntity {
     /// The owner of these factors
-    pub entity: AccountAddressOrIdentityAddress,
+    pub entity: AddressOfAccountOrPersona,
 
     /// Index and hash of transaction
     pub intent_hash: IntentHash,
@@ -21,7 +21,7 @@ pub struct PetitionEntity {
 impl PetitionEntity {
     pub fn new(
         intent_hash: IntentHash,
-        entity: AccountAddressOrIdentityAddress,
+        entity: AddressOfAccountOrPersona,
         threshold_factors: impl Into<Option<PetitionFactors>>,
         override_factors: impl Into<Option<PetitionFactors>>,
     ) -> Self {
@@ -40,7 +40,7 @@ impl PetitionEntity {
 
     pub fn new_securified(
         intent_hash: IntentHash,
-        entity: AccountAddressOrIdentityAddress,
+        entity: AddressOfAccountOrPersona,
         matrix: MatrixOfFactorInstances,
     ) -> Self {
         Self::new(
@@ -53,7 +53,7 @@ impl PetitionEntity {
 
     pub fn new_unsecurified(
         intent_hash: IntentHash,
-        entity: AccountAddressOrIdentityAddress,
+        entity: AddressOfAccountOrPersona,
         instance: FactorInstance,
     ) -> Self {
         Self::new(
@@ -262,7 +262,7 @@ impl PetitionEntity {
 }
 
 impl PetitionEntity {
-    fn from_entity(entity: Entity, intent_hash: IntentHash) -> Self {
+    fn from_entity(entity: AccountOrPersona, intent_hash: IntentHash) -> Self {
         match entity.security_state {
             EntitySecurityState::Securified(matrix) => {
                 Self::new_securified(intent_hash, entity.address, matrix)
@@ -275,10 +275,13 @@ impl PetitionEntity {
 }
 impl HasSampleValues for PetitionEntity {
     fn sample() -> Self {
-        Self::from_entity(Entity::sample_securified(), IntentHash::sample())
+        Self::from_entity(AccountOrPersona::sample_securified(), IntentHash::sample())
     }
     fn sample_other() -> Self {
-        Self::from_entity(Entity::sample_unsecurified(), IntentHash::sample_other())
+        Self::from_entity(
+            AccountOrPersona::sample_unsecurified(),
+            IntentHash::sample_other(),
+        )
     }
 }
 
@@ -292,7 +295,7 @@ mod tests {
     fn invalid_empty_factors() {
         Sut::new(
             IntentHash::sample(),
-            AccountAddressOrIdentityAddress::sample(),
+            AddressOfAccountOrPersona::sample(),
             None,
             None,
         );
@@ -308,7 +311,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "A factor MUST NOT be present in both threshold AND override list.")]
     fn factor_should_not_be_used_in_both_lists() {
-        Entity::securified_mainnet(0, "Jane Doe", |idx| {
+        AccountOrPersona::securified_mainnet(0, "Jane Doe", |idx| {
             let fi = FactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),
@@ -322,7 +325,7 @@ mod tests {
     #[should_panic]
     fn cannot_add_same_signature_twice() {
         let intent_hash = IntentHash::sample();
-        let entity = Entity::securified_mainnet(0, "Jane Doe", |idx| {
+        let entity = AccountOrPersona::securified_mainnet(0, "Jane Doe", |idx| {
             let fi = FactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [FactorSourceID::fs0()].map(&fi),

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -334,7 +334,7 @@ mod tests {
             intent_hash,
             OwnedFactorInstance::new(
                 entity.address(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     0,
                     FactorSourceID::fs0(),
                 ),
@@ -354,7 +354,7 @@ mod tests {
                 sut.intent_hash.clone(),
                 OwnedFactorInstance::new(
                     sut.entity.clone(),
-                    HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                         6,
                         FactorSourceID::fs1(),
                     ),

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -14,7 +14,11 @@ pub struct PetitionFactors {
 
 impl PetitionFactors {
     pub fn debug_str(&self) -> String {
-        format!("{:?}", self.state_snapshot())
+        format!(
+            "PetitionFactors(input: {:#?}, state_snapshot: {:#?})",
+            self.input,
+            self.state_snapshot()
+        )
     }
     pub fn new(factor_list_kind: FactorListKind, input: PetitionFactorsInput) -> Self {
         Self {

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -20,11 +20,11 @@ impl PetitionFactors {
         }
     }
 
-    pub fn factor_instances(&self) -> IndexSet<FactorInstance> {
+    pub fn factor_instances(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.input.factors.clone()
     }
 
-    pub fn all_skipped(&self) -> IndexSet<FactorInstance> {
+    pub fn all_skipped(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.state.borrow().all_skipped()
     }
 
@@ -32,7 +32,10 @@ impl PetitionFactors {
         self.state.borrow().all_signatures()
     }
 
-    pub fn new_threshold(factors: Vec<FactorInstance>, threshold: i8) -> Option<Self> {
+    pub fn new_threshold(
+        factors: Vec<HierarchicalDeterministicFactorInstance>,
+        threshold: i8,
+    ) -> Option<Self> {
         if factors.is_empty() {
             return None;
         }
@@ -42,11 +45,11 @@ impl PetitionFactors {
         ))
     }
 
-    pub fn new_unsecurified(factor: FactorInstance) -> Self {
+    pub fn new_unsecurified(factor: HierarchicalDeterministicFactorInstance) -> Self {
         Self::new_threshold(vec![factor], 1).unwrap() // define as 1/1 threshold factor, which is a good definition.
     }
 
-    pub fn new_override(factors: Vec<FactorInstance>) -> Option<Self> {
+    pub fn new_override(factors: Vec<HierarchicalDeterministicFactorInstance>) -> Option<Self> {
         if factors.is_empty() {
             return None;
         }
@@ -71,7 +74,10 @@ impl PetitionFactors {
         self.has_instance_with_id(owned_factor_instance.factor_instance())
     }
 
-    pub fn has_instance_with_id(&self, factor_instance: &FactorInstance) -> bool {
+    pub fn has_instance_with_id(
+        &self,
+        factor_instance: &HierarchicalDeterministicFactorInstance,
+    ) -> bool {
         self.input.factors.iter().any(|f| f == factor_instance)
     }
 
@@ -105,7 +111,7 @@ impl PetitionFactors {
     fn expect_reference_to_factor_source_with_id(
         &self,
         factor_source_id: &FactorSourceID,
-    ) -> &FactorInstance {
+    ) -> &HierarchicalDeterministicFactorInstance {
         self.reference_to_factor_source_with_id(factor_source_id)
             .expect("Programmer error! Factor source not found in factors.")
     }
@@ -113,7 +119,7 @@ impl PetitionFactors {
     fn reference_to_factor_source_with_id(
         &self,
         factor_source_id: &FactorSourceID,
-    ) -> Option<&FactorInstance> {
+    ) -> Option<&HierarchicalDeterministicFactorInstance> {
         self.input.reference_factor_source_with_id(factor_source_id)
     }
 

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -8,7 +8,7 @@ pub struct PetitionFactors {
     pub factor_list_kind: FactorListKind,
 
     /// Factors to sign with and the required number of them.
-    input: PetitionFactorsInput,
+    pub(crate) input: PetitionFactorsInput,
     state: RefCell<PetitionFactorsState>,
 }
 

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::prelude::*;
 
 /// Petition of signatures from a factors list of an entity in a transaction.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub struct PetitionFactors {
     pub factor_list_kind: FactorListKind,
 
@@ -12,6 +13,9 @@ pub struct PetitionFactors {
 }
 
 impl PetitionFactors {
+    pub fn debug_str(&self) -> String {
+        format!("{:?}", self.state_snapshot())
+    }
     pub fn new(factor_list_kind: FactorListKind, input: PetitionFactorsInput) -> Self {
         Self {
             factor_list_kind,

--- a/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
@@ -4,29 +4,35 @@ use crate::prelude::*;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PetitionFactorsInput {
     /// Factors to sign with.
-    pub(super) factors: IndexSet<FactorInstance>,
+    pub(super) factors: IndexSet<HierarchicalDeterministicFactorInstance>,
 
     /// Number of required factors to sign with.
     pub(super) required: i8,
 }
 
 impl PetitionFactorsInput {
-    pub(super) fn new(factors: IndexSet<FactorInstance>, required: i8) -> Self {
+    pub(super) fn new(
+        factors: IndexSet<HierarchicalDeterministicFactorInstance>,
+        required: i8,
+    ) -> Self {
         Self { factors, required }
     }
 
-    pub(super) fn new_threshold(factors: IndexSet<FactorInstance>, threshold: i8) -> Self {
+    pub(super) fn new_threshold(
+        factors: IndexSet<HierarchicalDeterministicFactorInstance>,
+        threshold: i8,
+    ) -> Self {
         Self::new(factors, threshold)
     }
 
-    pub(super) fn new_override(factors: IndexSet<FactorInstance>) -> Self {
+    pub(super) fn new_override(factors: IndexSet<HierarchicalDeterministicFactorInstance>) -> Self {
         Self::new(factors, 1) // we need just one, anyone, factor for threshold.
     }
 
     pub fn reference_factor_source_with_id(
         &self,
         factor_source_id: &FactorSourceID,
-    ) -> Option<&FactorInstance> {
+    ) -> Option<&HierarchicalDeterministicFactorInstance> {
         self.factors
             .iter()
             .find(|f| f.factor_source_id == *factor_source_id)

--- a/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::prelude::*;
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, derive_more::Debug)]
+#[debug("PetitionFactorsInput(factors: {:#?})", self.factors)]
 pub struct PetitionFactorsInput {
     /// Factors to sign with.
     pub(super) factors: IndexSet<HierarchicalDeterministicFactorInstance>,

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
@@ -50,7 +50,7 @@ impl PetitionFactorsState {
     fn assert_not_referencing_factor_source(&self, factor_source_id: FactorSourceID) {
         assert!(
             !self.references_factor_source_by_id(factor_source_id),
-            "Programmer error! Factor source {:?} already used, should only be referenced once.",
+            "Programmer error! Factor source {:#?} already used, should only be referenced once.",
             factor_source_id,
         );
     }

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
@@ -118,10 +118,7 @@ mod tests {
         let factor_instance = FactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
         let sign_input = HDSignatureInput::new(
             intent_hash,
-            OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
-                factor_instance.clone(),
-            ),
+            OwnedFactorInstance::new(AddressOfAccountOrPersona::sample(), factor_instance.clone()),
         );
         let signature = HDSignature::produced_signing_with_input(sign_input);
 
@@ -142,10 +139,7 @@ mod tests {
 
         let sign_input = HDSignatureInput::new(
             intent_hash,
-            OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
-                factor_instance.clone(),
-            ),
+            OwnedFactorInstance::new(AddressOfAccountOrPersona::sample(), factor_instance.clone()),
         );
 
         let signature = HDSignature::produced_signing_with_input(sign_input);

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
@@ -11,7 +11,7 @@ pub struct PetitionFactorsState {
     signed: RefCell<PetitionFactorsSubState<HDSignature>>,
 
     /// Factors that user skipped.
-    skipped: RefCell<PetitionFactorsSubState<FactorInstance>>,
+    skipped: RefCell<PetitionFactorsSubState<HierarchicalDeterministicFactorInstance>>,
 }
 
 impl PetitionFactorsState {
@@ -24,7 +24,9 @@ impl PetitionFactorsState {
     }
 
     /// A reference to the skipped factors so far.
-    pub(super) fn skipped(&self) -> Ref<PetitionFactorsSubState<FactorInstance>> {
+    pub(super) fn skipped(
+        &self,
+    ) -> Ref<PetitionFactorsSubState<HierarchicalDeterministicFactorInstance>> {
         self.skipped.borrow()
     }
 
@@ -39,7 +41,7 @@ impl PetitionFactorsState {
     }
 
     /// A set factors have been skipped so far.
-    pub fn all_skipped(&self) -> IndexSet<FactorInstance> {
+    pub fn all_skipped(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         self.skipped().snapshot()
     }
 
@@ -56,7 +58,11 @@ impl PetitionFactorsState {
     /// # Panics
     /// Panics if this factor source has already been skipped or signed and
     /// this is not a simulation.
-    pub(crate) fn did_skip(&self, factor_instance: &FactorInstance, simulated: bool) {
+    pub(crate) fn did_skip(
+        &self,
+        factor_instance: &HierarchicalDeterministicFactorInstance,
+        simulated: bool,
+    ) {
         if !simulated {
             self.assert_not_referencing_factor_source(factor_instance.factor_source_id);
         }
@@ -94,7 +100,7 @@ mod tests {
     #[should_panic]
     fn skipping_twice_panics() {
         let sut = Sut::new();
-        let fi = FactorInstance::sample();
+        let fi = HierarchicalDeterministicFactorInstance::sample();
         sut.did_skip(&fi, false);
         sut.did_skip(&fi, false);
     }
@@ -115,7 +121,8 @@ mod tests {
 
         let intent_hash = IntentHash::sample();
 
-        let factor_instance = FactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
+        let factor_instance =
+            HierarchicalDeterministicFactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
         let sign_input = HDSignatureInput::new(
             intent_hash,
             OwnedFactorInstance::new(AddressOfAccountOrPersona::sample(), factor_instance.clone()),
@@ -133,7 +140,8 @@ mod tests {
         let sut = Sut::new();
 
         let intent_hash = IntentHash::sample();
-        let factor_instance = FactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
+        let factor_instance =
+            HierarchicalDeterministicFactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
 
         sut.did_skip(&factor_instance, false);
 

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state.rs
@@ -122,7 +122,7 @@ mod tests {
         let intent_hash = IntentHash::sample();
 
         let factor_instance =
-            HierarchicalDeterministicFactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
+            HierarchicalDeterministicFactorInstance::mainnet_tx_account(0, FactorSourceID::fs0());
         let sign_input = HDSignatureInput::new(
             intent_hash,
             OwnedFactorInstance::new(AddressOfAccountOrPersona::sample(), factor_instance.clone()),
@@ -141,7 +141,7 @@ mod tests {
 
         let intent_hash = IntentHash::sample();
         let factor_instance =
-            HierarchicalDeterministicFactorInstance::account_mainnet_tx(0, FactorSourceID::fs0());
+            HierarchicalDeterministicFactorInstance::mainnet_tx_account(0, FactorSourceID::fs0());
 
         sut.did_skip(&factor_instance, false);
 

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -7,11 +7,14 @@ pub(super) struct PetitionFactorsStateSnapshot {
     signed: IndexSet<HDSignature>,
 
     /// Factors that user skipped.
-    skipped: IndexSet<FactorInstance>,
+    skipped: IndexSet<HierarchicalDeterministicFactorInstance>,
 }
 
 impl PetitionFactorsStateSnapshot {
-    pub(super) fn new(signed: IndexSet<HDSignature>, skipped: IndexSet<FactorInstance>) -> Self {
+    pub(super) fn new(
+        signed: IndexSet<HDSignature>,
+        skipped: IndexSet<HierarchicalDeterministicFactorInstance>,
+    ) -> Self {
         Self { signed, skipped }
     }
     pub(super) fn prompted_count(&self) -> i8 {

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -16,17 +16,16 @@ pub(super) struct PetitionFactorsStateSnapshot {
 impl PetitionFactorsStateSnapshot {
     fn debug_str(&self) -> String {
         format!(
-            "signatures: {:?}
-            skipped: {:?}",
+            "signatures: {:#?}, skipped: {:#?}",
             self.signed
                 .clone()
                 .into_iter()
-                .map(|s| format!("{:?}", s))
+                .map(|s| format!("{:#?}", s))
                 .join(", "),
             self.skipped
                 .clone()
                 .into_iter()
-                .map(|s| format!("{:?}", s))
+                .map(|s| format!("{:#?}", s))
                 .join(", ")
         )
     }

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -1,5 +1,3 @@
-use std::fmt::format;
-
 use crate::prelude::*;
 
 /// An immutable "snapshot" of `PetitionFactorsState`
@@ -14,6 +12,7 @@ pub(super) struct PetitionFactorsStateSnapshot {
 }
 
 impl PetitionFactorsStateSnapshot {
+    #[allow(unused)]
     fn debug_str(&self) -> String {
         format!(
             "signatures: {:#?}, skipped: {:#?}",

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -1,7 +1,10 @@
+use std::fmt::format;
+
 use crate::prelude::*;
 
 /// An immutable "snapshot" of `PetitionFactorsState`
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub(super) struct PetitionFactorsStateSnapshot {
     /// Factors that have signed.
     signed: IndexSet<HDSignature>,
@@ -11,6 +14,23 @@ pub(super) struct PetitionFactorsStateSnapshot {
 }
 
 impl PetitionFactorsStateSnapshot {
+    fn debug_str(&self) -> String {
+        format!(
+            "signatures: {:?}
+            skipped: {:?}",
+            self.signed
+                .clone()
+                .into_iter()
+                .map(|s| format!("{:?}", s))
+                .join(", "),
+            self.skipped
+                .clone()
+                .into_iter()
+                .map(|s| format!("{:?}", s))
+                .join(", ")
+        )
+    }
+
     pub(super) fn new(
         signed: IndexSet<HDSignature>,
         skipped: IndexSet<HierarchicalDeterministicFactorInstance>,

--- a/src/signing/petition_types/petition_factors_types/petition_factors_sub_state.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_sub_state.rs
@@ -38,7 +38,7 @@ pub trait FactorSourceReferencing: std::hash::Hash + PartialEq + Eq + Clone {
     fn factor_source_id(&self) -> FactorSourceID;
 }
 
-impl FactorSourceReferencing for FactorInstance {
+impl FactorSourceReferencing for HierarchicalDeterministicFactorInstance {
     fn factor_source_id(&self) -> FactorSourceID {
         self.factor_source_id
     }

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -2,6 +2,8 @@ use crate::prelude::*;
 
 /// Petition of signatures for a transaction.
 /// Essentially a wrapper around `Iterator<Item = PetitionEntity>`.
+#[derive(derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub(crate) struct PetitionTransaction {
     /// Hash of transaction to sign
     pub intent_hash: IntentHash,
@@ -10,6 +12,14 @@ pub(crate) struct PetitionTransaction {
 }
 
 impl PetitionTransaction {
+    fn debug_str(&self) -> String {
+        self.for_entities
+            .borrow()
+            .iter()
+            .map(|p| format!("{:?}", p.1))
+            .join(", ")
+    }
+
     /// Returns `(true, _)` if this transaction has been successfully signed by
     /// all required factor instances.
     ///

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -12,6 +12,7 @@ pub(crate) struct PetitionTransaction {
 }
 
 impl PetitionTransaction {
+    #[allow(unused)]
     fn debug_str(&self) -> String {
         let entities = self
             .for_entities

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -13,11 +13,14 @@ pub(crate) struct PetitionTransaction {
 
 impl PetitionTransaction {
     fn debug_str(&self) -> String {
-        self.for_entities
+        let entities = self
+            .for_entities
             .borrow()
             .iter()
-            .map(|p| format!("{:?}", p.1))
-            .join(", ")
+            .map(|p| format!("PetitionEntity({:#?})", p.1))
+            .join(", ");
+
+        format!("PetitionTransaction(for_entities: [{}])", entities)
     }
 
     /// Returns `(true, _)` if this transaction has been successfully signed by

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -6,7 +6,7 @@ pub(crate) struct PetitionTransaction {
     /// Hash of transaction to sign
     pub intent_hash: IntentHash,
 
-    pub for_entities: RefCell<HashMap<AccountAddressOrIdentityAddress, PetitionEntity>>,
+    pub for_entities: RefCell<HashMap<AddressOfAccountOrPersona, PetitionEntity>>,
 }
 
 impl PetitionTransaction {
@@ -103,7 +103,7 @@ impl PetitionTransaction {
 
     pub(crate) fn new(
         intent_hash: IntentHash,
-        for_entities: HashMap<AccountAddressOrIdentityAddress, PetitionEntity>,
+        for_entities: HashMap<AddressOfAccountOrPersona, PetitionEntity>,
     ) -> Self {
         Self {
             intent_hash,

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -28,8 +28,8 @@ impl Petitions {
         self.txid_to_petition
             .borrow()
             .iter()
-            .map(|p| format!("{:?}: {:?}", p.0, p.1))
-            .join("\n")
+            .map(|p| format!("Petitions({:#?}: {:#?})", p.0, p.1))
+            .join(" + ")
     }
     pub fn outcome(self) -> SignaturesOutcome {
         let txid_to_petition = self.txid_to_petition.into_inner();

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -24,6 +24,7 @@ pub(crate) struct Petitions {
 }
 
 impl Petitions {
+    #[allow(unused)]
     fn debug_str(&self) -> String {
         self.txid_to_petition
             .borrow()

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -2,6 +2,8 @@
 
 use crate::prelude::*;
 
+#[derive(derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub(crate) struct Petitions {
     /// Lookup from factor to TXID.
     ///
@@ -22,6 +24,13 @@ pub(crate) struct Petitions {
 }
 
 impl Petitions {
+    fn debug_str(&self) -> String {
+        self.txid_to_petition
+            .borrow()
+            .iter()
+            .map(|p| format!("{:?}: {:?}", p.0, p.1))
+            .join("\n")
+    }
     pub fn outcome(self) -> SignaturesOutcome {
         let txid_to_petition = self.txid_to_petition.into_inner();
         let mut failed_transactions = MaybeSignedTransactions::empty();

--- a/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
+++ b/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
@@ -94,14 +94,14 @@ impl HasSampleValues for MaybeSignedTransactions {
         let tx_a_input_x = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
             ),
         );
         let tx_a_input_y = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(1, FactorSourceID::sample_other()),
             ),
         );
@@ -112,14 +112,14 @@ impl HasSampleValues for MaybeSignedTransactions {
         let tx_b_input_x = HDSignatureInput::new(
             tx_b.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(2, FactorSourceID::sample_third()),
             ),
         );
         let tx_b_input_y = HDSignatureInput::new(
             tx_b.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(3, FactorSourceID::sample_fourth()),
             ),
         );
@@ -142,21 +142,21 @@ impl HasSampleValues for MaybeSignedTransactions {
         let tx_a_input_x = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(10, FactorSourceID::sample()),
             ),
         );
         let tx_a_input_y = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(11, FactorSourceID::sample_other()),
             ),
         );
         let tx_a_input_z = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(12, FactorSourceID::sample_third()),
             ),
         );
@@ -202,7 +202,7 @@ mod tests {
         let input = HDSignatureInput::new(
             tx.clone(),
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
             ),
         );
@@ -219,7 +219,7 @@ mod tests {
         let input = HDSignatureInput::new(
             tx,
             OwnedFactorInstance::new(
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
                 FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
             ),
         );

--- a/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
+++ b/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
@@ -95,14 +95,20 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    0,
+                    FactorSourceID::sample(),
+                ),
             ),
         );
         let tx_a_input_y = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(1, FactorSourceID::sample_other()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    1,
+                    FactorSourceID::sample_other(),
+                ),
             ),
         );
         let tx_a_sig_x = HDSignature::produced_signing_with_input(tx_a_input_x);
@@ -113,14 +119,20 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_b.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(2, FactorSourceID::sample_third()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    2,
+                    FactorSourceID::sample_third(),
+                ),
             ),
         );
         let tx_b_input_y = HDSignatureInput::new(
             tx_b.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(3, FactorSourceID::sample_fourth()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    3,
+                    FactorSourceID::sample_fourth(),
+                ),
             ),
         );
 
@@ -143,21 +155,30 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(10, FactorSourceID::sample()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    10,
+                    FactorSourceID::sample(),
+                ),
             ),
         );
         let tx_a_input_y = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(11, FactorSourceID::sample_other()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    11,
+                    FactorSourceID::sample_other(),
+                ),
             ),
         );
         let tx_a_input_z = HDSignatureInput::new(
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(12, FactorSourceID::sample_third()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    12,
+                    FactorSourceID::sample_third(),
+                ),
             ),
         );
         let tx_a_sig_x = HDSignature::produced_signing_with_input(tx_a_input_x);
@@ -203,7 +224,10 @@ mod tests {
             tx.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    0,
+                    FactorSourceID::sample(),
+                ),
             ),
         );
         let signature = HDSignature::produced_signing_with_input(input);
@@ -220,7 +244,10 @@ mod tests {
             tx,
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                FactorInstance::account_mainnet_tx(0, FactorSourceID::sample()),
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    0,
+                    FactorSourceID::sample(),
+                ),
             ),
         );
         let signature = HDSignature::produced_signing_with_input(input);

--- a/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
+++ b/src/signing/signatures_outcome_types/maybe_signed_transactions.rs
@@ -95,7 +95,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     0,
                     FactorSourceID::sample(),
                 ),
@@ -105,7 +105,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     1,
                     FactorSourceID::sample_other(),
                 ),
@@ -119,7 +119,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_b.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     2,
                     FactorSourceID::sample_third(),
                 ),
@@ -129,7 +129,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_b.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     3,
                     FactorSourceID::sample_fourth(),
                 ),
@@ -155,7 +155,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     10,
                     FactorSourceID::sample(),
                 ),
@@ -165,7 +165,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     11,
                     FactorSourceID::sample_other(),
                 ),
@@ -175,7 +175,7 @@ impl HasSampleValues for MaybeSignedTransactions {
             tx_a.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     12,
                     FactorSourceID::sample_third(),
                 ),
@@ -224,7 +224,7 @@ mod tests {
             tx.clone(),
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     0,
                     FactorSourceID::sample(),
                 ),
@@ -244,7 +244,7 @@ mod tests {
             tx,
             OwnedFactorInstance::new(
                 AddressOfAccountOrPersona::sample(),
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     0,
                     FactorSourceID::sample(),
                 ),

--- a/src/signing/tx_to_sign.rs
+++ b/src/signing/tx_to_sign.rs
@@ -7,16 +7,22 @@ pub struct TXToSign {
 }
 
 impl TXToSign {
-    pub fn new(
+    pub fn with(
+        intent_hash: IntentHash,
         entities_requiring_auth: impl IntoIterator<Item = impl Into<AccountOrPersona>>,
     ) -> Self {
         Self {
-            intent_hash: IntentHash::generate(),
+            intent_hash,
             entities_requiring_auth: entities_requiring_auth
                 .into_iter()
                 .map(|i| i.into())
                 .collect_vec(),
         }
+    }
+    pub fn new(
+        entities_requiring_auth: impl IntoIterator<Item = impl Into<AccountOrPersona>>,
+    ) -> Self {
+        Self::with(IntentHash::generate(), entities_requiring_auth)
     }
 
     pub fn entities_requiring_auth(&self) -> IndexSet<AccountOrPersona> {

--- a/src/signing/tx_to_sign.rs
+++ b/src/signing/tx_to_sign.rs
@@ -1,0 +1,21 @@
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+pub struct TXToSign {
+    pub intent_hash: IntentHash,
+    pub entities_requiring_auth: Vec<AccountOrPersona>, // should be a set but Sets are not `Hash`.
+}
+
+impl TXToSign {
+    pub fn new(
+        entities_requiring_auth: impl IntoIterator<Item = impl Into<AccountOrPersona>>,
+    ) -> Self {
+        Self {
+            intent_hash: IntentHash::generate(),
+            entities_requiring_auth: entities_requiring_auth
+                .into_iter()
+                .map(|i| i.into())
+                .collect_vec(),
+        }
+    }
+}

--- a/src/signing/tx_to_sign.rs
+++ b/src/signing/tx_to_sign.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub struct TXToSign {
     pub intent_hash: IntentHash,
-    pub entities_requiring_auth: Vec<AccountOrPersona>, // should be a set but Sets are not `Hash`.
+    entities_requiring_auth: Vec<AccountOrPersona>, // should be a set but Sets are not `Hash`.
 }
 
 impl TXToSign {
@@ -17,5 +17,9 @@ impl TXToSign {
                 .map(|i| i.into())
                 .collect_vec(),
         }
+    }
+
+    pub fn entities_requiring_auth(&self) -> IndexSet<AccountOrPersona> {
+        self.entities_requiring_auth.clone().into_iter().collect()
     }
 }

--- a/src/testing/derivation/test_keys_collector.rs
+++ b/src/testing/derivation/test_keys_collector.rs
@@ -153,7 +153,7 @@ impl KeysCollector {
     pub fn with(
         factor_source: &FactorSource,
         network_id: NetworkID,
-        key_kind: KeyKind,
+        key_kind: CAP26KeyKind,
         entity_kind: EntityKind,
         key_space: KeySpace,
     ) -> Self {

--- a/src/testing/derivation/test_keys_collector.rs
+++ b/src/testing/derivation/test_keys_collector.rs
@@ -154,7 +154,7 @@ impl KeysCollector {
         factor_source: &FactorSource,
         network_id: NetworkID,
         key_kind: CAP26KeyKind,
-        entity_kind: EntityKind,
+        entity_kind: CAP26EntityKind,
         key_space: KeySpace,
     ) -> Self {
         let indices = StatelessDummyIndices;

--- a/src/testing/derivation/test_keys_collector.rs
+++ b/src/testing/derivation/test_keys_collector.rs
@@ -159,7 +159,7 @@ impl KeysCollector {
     ) -> Self {
         let indices = StatelessDummyIndices;
         let path = indices.next_derivation_path(
-            factor_source.clone().id,
+            factor_source.clone().factor_source_id(),
             network_id,
             key_kind,
             entity_kind,
@@ -167,7 +167,10 @@ impl KeysCollector {
         );
         Self::new_test_with_factor_sources(
             [factor_source.clone()],
-            [(factor_source.id, IndexSet::from_iter([path]))],
+            [(
+                factor_source.factor_source_id(),
+                IndexSet::from_iter([path]),
+            )],
         )
     }
 }

--- a/src/testing/derivation/test_keys_collector.rs
+++ b/src/testing/derivation/test_keys_collector.rs
@@ -43,18 +43,25 @@ impl KeysCollectingInteractors for TestDerivationInteractors {
 }
 
 pub struct TestDerivationParallelInteractor {
-    handle: fn(SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>>,
+    handle: fn(
+        SerialBatchKeyDerivationRequest,
+    ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>>,
 }
 impl TestDerivationParallelInteractor {
     pub fn new(
-        handle: fn(SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>>,
+        handle: fn(
+            SerialBatchKeyDerivationRequest,
+        ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>>,
     ) -> Self {
         Self { handle }
     }
     pub fn fail() -> Self {
         Self::new(|_| Err(CommonError::Failure))
     }
-    fn derive(&self, request: SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>> {
+    fn derive(
+        &self,
+        request: SerialBatchKeyDerivationRequest,
+    ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>> {
         (self.handle)(request)
     }
 }
@@ -66,12 +73,12 @@ impl Default for TestDerivationParallelInteractor {
 
 fn do_derive_serially(
     request: SerialBatchKeyDerivationRequest,
-) -> Result<IndexSet<FactorInstance>> {
+) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>> {
     let factor_source_id = &request.factor_source_id;
     let instances = request
         .derivation_paths
         .into_iter()
-        .map(|p| FactorInstance::mocked_with(p, factor_source_id))
+        .map(|p| HierarchicalDeterministicFactorInstance::mocked_with(p, factor_source_id))
         .collect::<IndexSet<_>>();
 
     Ok(instances)
@@ -83,7 +90,9 @@ impl DeriveKeyWithFactorParallelInteractor for TestDerivationParallelInteractor 
         &self,
         request: ParallelBatchKeyDerivationRequest,
     ) -> Result<BatchDerivationResponse> {
-        let pairs_result: Result<IndexMap<FactorSourceID, IndexSet<FactorInstance>>> = request
+        let pairs_result: Result<
+            IndexMap<FactorSourceID, IndexSet<HierarchicalDeterministicFactorInstance>>,
+        > = request
             .per_factor_source
             .into_iter()
             .map(|(k, r)| {
@@ -97,18 +106,25 @@ impl DeriveKeyWithFactorParallelInteractor for TestDerivationParallelInteractor 
 }
 
 pub struct TestDerivationSerialInteractor {
-    handle: fn(SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>>,
+    handle: fn(
+        SerialBatchKeyDerivationRequest,
+    ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>>,
 }
 impl TestDerivationSerialInteractor {
     pub fn new(
-        handle: fn(SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>>,
+        handle: fn(
+            SerialBatchKeyDerivationRequest,
+        ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>>,
     ) -> Self {
         Self { handle }
     }
     pub fn fail() -> Self {
         Self::new(|_| Err(CommonError::Failure))
     }
-    fn derive(&self, request: SerialBatchKeyDerivationRequest) -> Result<IndexSet<FactorInstance>> {
+    fn derive(
+        &self,
+        request: SerialBatchKeyDerivationRequest,
+    ) -> Result<IndexSet<HierarchicalDeterministicFactorInstance>> {
         (self.handle)(request)
     }
 }

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -139,7 +139,7 @@ impl FactorInstance {
     }
 }
 
-impl AccountOrPersona {
+impl Account {
     /// Alice | 0 | Unsecurified { Device }
     pub fn a0() -> Self {
         Self::unsecurified_mainnet(0, "Alice", FactorSourceID::fs0())

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -220,3 +220,40 @@ impl Account {
         })
     }
 }
+
+impl Persona {
+    /// Satoshi | 0 | Securified { Threshold #3 and Override factors #2  }
+    pub fn p0() -> Self {
+        type F = FactorSourceID;
+        Self::securified_mainnet(0, "Satoshi", |idx| {
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
+            MatrixOfFactorInstances::new(
+                [F::fs0(), F::fs3(), F::fs5()].map(&fi),
+                2,
+                [F::fs1(), F::fs4()].map(&fi),
+            )
+        })
+    }
+
+    /// Batman | 1 | Securified { Threshold only # 5/5 }
+    pub fn p1() -> Self {
+        type F = FactorSourceID;
+        Self::securified_mainnet(1, "Batman", |idx| {
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
+            MatrixOfFactorInstances::threshold_only(
+                [F::fs2(), F::fs6(), F::fs7(), F::fs8(), F::fs9()].map(&fi),
+                5,
+            )
+        })
+    }
+
+    /// Ziggy Stardust  | 2 | Securified { Override factors only #2 }
+    pub fn p2() -> Self {
+        type F = FactorSourceID;
+        Self::securified_mainnet(2, "Ziggy Stardust", |idx| {
+            MatrixOfFactorInstances::override_only(
+                [F::fs1(), F::fs4()].map(HierarchicalDeterministicFactorInstance::f(idx)),
+            )
+        })
+    }
+}

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -134,8 +134,69 @@ impl FactorSourceID {
 }
 
 impl HierarchicalDeterministicFactorInstance {
-    pub fn f(idx: u32) -> impl Fn(FactorSourceID) -> Self {
-        move |id: FactorSourceID| Self::mainnet_tx(CAP26EntityKind::Account, idx, id)
+    pub fn f(entity_kind: CAP26EntityKind, idx: u32) -> impl Fn(FactorSourceID) -> Self {
+        move |id: FactorSourceID| Self::mainnet_tx(entity_kind, idx, id)
+    }
+}
+
+impl MatrixOfFactorInstances {
+    /// Securified { Single Threshold only }
+    pub fn m2<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        Self::single_threshold(fi(FactorSourceID::fs0()))
+    }
+
+    /// Securified { Single Override only }
+    pub fn m3<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        Self::single_override(fi(FactorSourceID::fs1()))
+    }
+
+    /// Securified { Threshold factors only #3 }
+    pub fn m4<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        type F = FactorSourceID;
+        Self::threshold_only([F::fs0(), F::fs3(), F::fs5()].map(fi), 2)
+    }
+
+    /// Securified { Override factors only #2 }
+    pub fn m5<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        type F = FactorSourceID;
+        Self::override_only([F::fs1(), F::fs4()].map(&fi))
+    }
+
+    /// Securified { Threshold #3 and Override factors #2  }
+    pub fn m6<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        type F = FactorSourceID;
+        Self::new(
+            [F::fs0(), F::fs3(), F::fs5()].map(&fi),
+            2,
+            [F::fs1(), F::fs4()].map(&fi),
+        )
+    }
+
+    /// Securified { Threshold only # 5/5 }
+    pub fn m7<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceID) -> HierarchicalDeterministicFactorInstance,
+    {
+        type F = FactorSourceID;
+        Self::threshold_only(
+            [F::fs2(), F::fs6(), F::fs7(), F::fs8(), F::fs9()].map(&fi),
+            5,
+        )
     }
 }
 
@@ -153,107 +214,132 @@ impl Account {
     /// Carla | 2 | Securified { Single Threshold only }
     pub fn a2() -> Self {
         Self::securified_mainnet(2, "Carla", |idx| {
-            MatrixOfFactorInstances::single_threshold(
-                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
-                    idx,
-                    FactorSourceID::fs0(),
-                ),
-            )
+            MatrixOfFactorInstances::m2(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
     /// David | 3 | Securified { Single Override only }
     pub fn a3() -> Self {
         Self::securified_mainnet(3, "David", |idx| {
-            MatrixOfFactorInstances::single_override(
-                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
-                    idx,
-                    FactorSourceID::fs1(),
-                ),
-            )
+            MatrixOfFactorInstances::m3(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
     /// Emily | 4 | Securified { Threshold factors only #3 }
     pub fn a4() -> Self {
-        type F = FactorSourceID;
         Self::securified_mainnet(4, "Emily", |idx| {
-            MatrixOfFactorInstances::threshold_only(
-                [F::fs0(), F::fs3(), F::fs5()].map(HierarchicalDeterministicFactorInstance::f(idx)),
-                2,
-            )
+            MatrixOfFactorInstances::m4(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
     /// Frank | 5 | Securified { Override factors only #2 }
     pub fn a5() -> Self {
-        type F = FactorSourceID;
         Self::securified_mainnet(5, "Frank", |idx| {
-            MatrixOfFactorInstances::override_only(
-                [F::fs1(), F::fs4()].map(HierarchicalDeterministicFactorInstance::f(idx)),
-            )
+            MatrixOfFactorInstances::m5(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
     /// Grace | 6 | Securified { Threshold #3 and Override factors #2  }
     pub fn a6() -> Self {
-        type F = FactorSourceID;
         Self::securified_mainnet(6, "Grace", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
-            MatrixOfFactorInstances::new(
-                [F::fs0(), F::fs3(), F::fs5()].map(&fi),
-                2,
-                [F::fs1(), F::fs4()].map(&fi),
-            )
+            MatrixOfFactorInstances::m6(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
     /// Ida | 7 | Securified { Threshold only # 5/5 }
     pub fn a7() -> Self {
-        type F = FactorSourceID;
         Self::securified_mainnet(7, "Ida", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
-            MatrixOfFactorInstances::threshold_only(
-                [F::fs2(), F::fs6(), F::fs7(), F::fs8(), F::fs9()].map(&fi),
-                5,
-            )
+            MatrixOfFactorInstances::m7(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 }
 
 impl Persona {
-    /// Satoshi | 0 | Securified { Threshold #3 and Override factors #2  }
+    /// Satoshi | 0 | Unsecurified { Device }
     pub fn p0() -> Self {
-        type F = FactorSourceID;
-        Self::securified_mainnet(0, "Satoshi", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
-            MatrixOfFactorInstances::new(
-                [F::fs0(), F::fs3(), F::fs5()].map(&fi),
-                2,
-                [F::fs1(), F::fs4()].map(&fi),
-            )
-        })
+        Self::unsecurified_mainnet(0, "Satoshi", FactorSourceID::fs0())
     }
 
-    /// Batman | 1 | Securified { Threshold only # 5/5 }
+    /// Batman | 1 | Unsecurified { Ledger }
     pub fn p1() -> Self {
-        type F = FactorSourceID;
-        Self::securified_mainnet(1, "Batman", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
-            MatrixOfFactorInstances::threshold_only(
-                [F::fs2(), F::fs6(), F::fs7(), F::fs8(), F::fs9()].map(&fi),
-                5,
-            )
+        Self::unsecurified_mainnet(1, "Batman", FactorSourceID::fs1())
+    }
+
+    /// Ziggy | 2 | Securified { Single Threshold only }
+    pub fn p2() -> Self {
+        Self::securified_mainnet(2, "Ziggy", |idx| {
+            MatrixOfFactorInstances::m2(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 
-    /// Ziggy Stardust  | 2 | Securified { Override factors only #2 }
-    pub fn p2() -> Self {
-        type F = FactorSourceID;
-        Self::securified_mainnet(2, "Ziggy Stardust", |idx| {
-            MatrixOfFactorInstances::override_only(
-                [F::fs1(), F::fs4()].map(HierarchicalDeterministicFactorInstance::f(idx)),
-            )
+    /// Superman | 3 | Securified { Single Override only }
+    pub fn p3() -> Self {
+        Self::securified_mainnet(3, "Superman", |idx| {
+            MatrixOfFactorInstances::m3(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
+        })
+    }
+
+    /// Banksy | 4 | Securified { Threshold factors only #3 }
+    pub fn p4() -> Self {
+        Self::securified_mainnet(4, "Banksy", |idx| {
+            MatrixOfFactorInstances::m4(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
+        })
+    }
+
+    /// Voltaire | 5 | Securified { Override factors only #2 }
+    pub fn p5() -> Self {
+        Self::securified_mainnet(5, "Voltaire", |idx| {
+            MatrixOfFactorInstances::m5(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
+        })
+    }
+
+    /// Kasparov | 6 | Securified { Threshold #3 and Override factors #2  }
+    pub fn p6() -> Self {
+        Self::securified_mainnet(6, "Kasparov", |idx| {
+            MatrixOfFactorInstances::m6(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
+        })
+    }
+
+    /// Pelé | 7 | Securified { Threshold only # 5/5 }
+    pub fn p7() -> Self {
+        Self::securified_mainnet(7, "Pelé", |idx| {
+            MatrixOfFactorInstances::m7(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 }

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -78,7 +78,7 @@ pub fn fs_at(index: usize) -> FactorSource {
 }
 
 pub fn fs_id_at(index: usize) -> FactorSourceID {
-    fs_at(index).id
+    fs_at(index).factor_source_id()
 }
 
 impl FactorSourceID {

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -135,7 +135,7 @@ impl FactorSourceID {
 
 impl HierarchicalDeterministicFactorInstance {
     pub fn f(idx: u32) -> impl Fn(FactorSourceID) -> Self {
-        move |id: FactorSourceID| Self::account_mainnet_tx(idx, id)
+        move |id: FactorSourceID| Self::mainnet_tx(CAP26EntityKind::Account, idx, id)
     }
 }
 
@@ -154,7 +154,7 @@ impl Account {
     pub fn a2() -> Self {
         Self::securified_mainnet(2, "Carla", |idx| {
             MatrixOfFactorInstances::single_threshold(
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     idx,
                     FactorSourceID::fs0(),
                 ),
@@ -166,7 +166,7 @@ impl Account {
     pub fn a3() -> Self {
         Self::securified_mainnet(3, "David", |idx| {
             MatrixOfFactorInstances::single_override(
-                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                     idx,
                     FactorSourceID::fs1(),
                 ),

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -139,7 +139,7 @@ impl FactorInstance {
     }
 }
 
-impl Entity {
+impl AccountOrPersona {
     /// Alice | 0 | Unsecurified { Device }
     pub fn a0() -> Self {
         Self::unsecurified_mainnet(0, "Alice", FactorSourceID::fs0())

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -133,7 +133,7 @@ impl FactorSourceID {
     }
 }
 
-impl FactorInstance {
+impl HierarchicalDeterministicFactorInstance {
     pub fn f(idx: u32) -> impl Fn(FactorSourceID) -> Self {
         move |id: FactorSourceID| Self::account_mainnet_tx(idx, id)
     }
@@ -153,20 +153,24 @@ impl Account {
     /// Carla | 2 | Securified { Single Threshold only }
     pub fn a2() -> Self {
         Self::securified_mainnet(2, "Carla", |idx| {
-            MatrixOfFactorInstances::single_threshold(FactorInstance::account_mainnet_tx(
-                idx,
-                FactorSourceID::fs0(),
-            ))
+            MatrixOfFactorInstances::single_threshold(
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    idx,
+                    FactorSourceID::fs0(),
+                ),
+            )
         })
     }
 
     /// David | 3 | Securified { Single Override only }
     pub fn a3() -> Self {
         Self::securified_mainnet(3, "David", |idx| {
-            MatrixOfFactorInstances::single_override(FactorInstance::account_mainnet_tx(
-                idx,
-                FactorSourceID::fs1(),
-            ))
+            MatrixOfFactorInstances::single_override(
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    idx,
+                    FactorSourceID::fs1(),
+                ),
+            )
         })
     }
 
@@ -175,7 +179,7 @@ impl Account {
         type F = FactorSourceID;
         Self::securified_mainnet(4, "Emily", |idx| {
             MatrixOfFactorInstances::threshold_only(
-                [F::fs0(), F::fs3(), F::fs5()].map(FactorInstance::f(idx)),
+                [F::fs0(), F::fs3(), F::fs5()].map(HierarchicalDeterministicFactorInstance::f(idx)),
                 2,
             )
         })
@@ -185,7 +189,9 @@ impl Account {
     pub fn a5() -> Self {
         type F = FactorSourceID;
         Self::securified_mainnet(5, "Frank", |idx| {
-            MatrixOfFactorInstances::override_only([F::fs1(), F::fs4()].map(FactorInstance::f(idx)))
+            MatrixOfFactorInstances::override_only(
+                [F::fs1(), F::fs4()].map(HierarchicalDeterministicFactorInstance::f(idx)),
+            )
         })
     }
 
@@ -193,7 +199,7 @@ impl Account {
     pub fn a6() -> Self {
         type F = FactorSourceID;
         Self::securified_mainnet(6, "Grace", |idx| {
-            let fi = FactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [F::fs0(), F::fs3(), F::fs5()].map(&fi),
                 2,
@@ -206,7 +212,7 @@ impl Account {
     pub fn a7() -> Self {
         type F = FactorSourceID;
         Self::securified_mainnet(7, "Ida", |idx| {
-            let fi = FactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
             MatrixOfFactorInstances::threshold_only(
                 [F::fs2(), F::fs6(), F::fs7(), F::fs8(), F::fs9()].map(&fi),
                 5,

--- a/src/testing/signing/test_signatures_collector.rs
+++ b/src/testing/signing/test_signatures_collector.rs
@@ -3,18 +3,19 @@ use crate::prelude::*;
 impl SignaturesCollector {
     pub fn new_test(
         all_factor_sources_in_profile: impl IntoIterator<Item = FactorSource>,
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
         simulated_user: SimulatedUser,
     ) -> Self {
-        Self::new(
+        Self::with(
             all_factor_sources_in_profile.into_iter().collect(),
             transactions.into_iter().collect(),
             Arc::new(TestSignatureCollectingInteractors::new(simulated_user)),
         )
     }
+
     pub fn test_prudent_with_factors(
         all_factor_sources_in_profile: impl IntoIterator<Item = FactorSource>,
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
     ) -> Self {
         Self::new_test(
             all_factor_sources_in_profile,
@@ -23,12 +24,12 @@ impl SignaturesCollector {
         )
     }
 
-    pub fn test_prudent(transactions: impl IntoIterator<Item = TransactionIntent>) -> Self {
+    pub fn test_prudent(transactions: impl IntoIterator<Item = TXToSign>) -> Self {
         Self::test_prudent_with_factors(FactorSource::all(), transactions)
     }
 
     pub fn test_prudent_with_failures(
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
         simulated_failures: SimulatedFailures,
     ) -> Self {
         Self::new_test(
@@ -40,7 +41,7 @@ impl SignaturesCollector {
 
     pub fn test_lazy_sign_minimum_no_failures_with_factors(
         all_factor_sources_in_profile: impl IntoIterator<Item = FactorSource>,
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
     ) -> Self {
         Self::new_test(
             all_factor_sources_in_profile,
@@ -50,14 +51,14 @@ impl SignaturesCollector {
     }
 
     pub fn test_lazy_sign_minimum_no_failures(
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
     ) -> Self {
         Self::test_lazy_sign_minimum_no_failures_with_factors(FactorSource::all(), transactions)
     }
 
     pub fn test_lazy_always_skip_with_factors(
         all_factor_sources_in_profile: impl IntoIterator<Item = FactorSource>,
-        transactions: impl IntoIterator<Item = TransactionIntent>,
+        transactions: impl IntoIterator<Item = TXToSign>,
     ) -> Self {
         Self::new_test(
             all_factor_sources_in_profile,
@@ -66,9 +67,7 @@ impl SignaturesCollector {
         )
     }
 
-    pub fn test_lazy_always_skip(
-        transactions: impl IntoIterator<Item = TransactionIntent>,
-    ) -> Self {
+    pub fn test_lazy_always_skip(transactions: impl IntoIterator<Item = TXToSign>) -> Self {
         Self::test_lazy_always_skip_with_factors(FactorSource::all(), transactions)
     }
 }

--- a/src/types/factor_sources_of_kind.rs
+++ b/src/types/factor_sources_of_kind.rs
@@ -32,7 +32,10 @@ impl FactorSourcesOfKind {
     }
 
     pub(crate) fn factor_source_ids(&self) -> Vec<FactorSourceID> {
-        self.factor_sources.iter().map(|f| f.id).collect()
+        self.factor_sources
+            .iter()
+            .map(|f| f.factor_source_id())
+            .collect()
     }
 }
 

--- a/src/types/factor_sources_of_kind.rs
+++ b/src/types/factor_sources_of_kind.rs
@@ -15,7 +15,10 @@ impl FactorSourcesOfKind {
         if factor_sources.is_empty() {
             return Err(CommonError::FactorSourcesOfKindEmptyFactors);
         }
-        if factor_sources.iter().any(|f| f.kind() != kind) {
+        if factor_sources
+            .iter()
+            .any(|f| f.factor_source_kind() != kind)
+        {
             return Err(CommonError::InvalidFactorSourceKind);
         }
         Ok(Self {

--- a/src/types/hd_signature.rs
+++ b/src/types/hd_signature.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// A signature of `intent_hash` by `entity` using `factor_source_id` and `derivation_path`, with `public_key` used for verification.
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::Debug)]
-#[debug("HDSignature {{ input: {:?} }}", input)]
+#[debug("HDSignature {{ input: {:#?} }}", input)]
 pub struct HDSignature {
     /// The input used to produce this `HDSignature`
     pub input: HDSignatureInput,

--- a/src/types/hd_signature.rs
+++ b/src/types/hd_signature.rs
@@ -39,6 +39,13 @@ impl HDSignature {
             .factor_instance()
             .factor_source_id
     }
+
+    pub fn derivation_path(&self) -> DerivationPath {
+        self.input
+            .owned_factor_instance
+            .factor_instance()
+            .derivation_path()
+    }
 }
 
 impl HasSampleValues for HDSignature {

--- a/src/types/hd_signature_input.rs
+++ b/src/types/hd_signature_input.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 /// has the same signer, which would be a bug.
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::Debug)]
 #[debug(
-    "HDSignatureInput {{ intent_hash: {:?}, owned_factor_instance: {:?} }}",
+    "HDSignatureInput {{ intent_hash: {:#?}, owned_factor_instance: {:#?} }}",
     intent_hash,
     owned_factor_instance
 )]

--- a/src/types/invalid_transaction_if_skipped.rs
+++ b/src/types/invalid_transaction_if_skipped.rs
@@ -9,7 +9,7 @@ pub struct InvalidTransactionIfSkipped {
     pub intent_hash: IntentHash,
 
     /// The entities in the transaction which would fail auth.
-    entities_which_would_fail_auth: Vec<AccountAddressOrIdentityAddress>,
+    entities_which_would_fail_auth: Vec<AddressOfAccountOrPersona>,
 }
 
 impl InvalidTransactionIfSkipped {
@@ -20,7 +20,7 @@ impl InvalidTransactionIfSkipped {
     /// Panics if `entities_which_would_fail_auth` is empty.
     pub fn new(
         intent_hash: IntentHash,
-        entities_which_would_fail_auth: impl IntoIterator<Item = AccountAddressOrIdentityAddress>,
+        entities_which_would_fail_auth: impl IntoIterator<Item = AddressOfAccountOrPersona>,
     ) -> Self {
         let entities_which_would_fail_auth =
             entities_which_would_fail_auth.into_iter().collect_vec();
@@ -44,7 +44,7 @@ impl InvalidTransactionIfSkipped {
         }
     }
 
-    pub fn entities_which_would_fail_auth(&self) -> IndexSet<AccountAddressOrIdentityAddress> {
+    pub fn entities_which_would_fail_auth(&self) -> IndexSet<AddressOfAccountOrPersona> {
         IndexSet::from_iter(self.entities_which_would_fail_auth.clone())
     }
 }
@@ -68,8 +68,8 @@ mod tests {
         Sut::new(
             IntentHash::sample(),
             [
-                AccountAddressOrIdentityAddress::sample(),
-                AccountAddressOrIdentityAddress::sample(),
+                AddressOfAccountOrPersona::sample(),
+                AddressOfAccountOrPersona::sample(),
             ],
         );
     }
@@ -77,8 +77,8 @@ mod tests {
     #[test]
     fn new() {
         let entities = [
-            AccountAddressOrIdentityAddress::sample(),
-            AccountAddressOrIdentityAddress::sample_other(),
+            AddressOfAccountOrPersona::sample(),
+            AddressOfAccountOrPersona::sample_other(),
         ];
         let sut = Sut::new(IntentHash::sample(), entities.clone());
         assert_eq!(

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,7 @@ mod invalid_transaction_if_skipped;
 mod owned_types;
 mod sargon_types;
 mod sign_with_factor_source_or_sources_outcome;
+mod new_methods_on_sargon_types;
 
 pub(crate) use factor_sources_of_kind::*;
 pub use hd_signature::*;
@@ -12,4 +13,5 @@ pub use hd_signature_input::*;
 pub use invalid_transaction_if_skipped::*;
 pub use owned_types::*;
 pub use sargon_types::*;
+pub use new_methods_on_sargon_types::*;
 pub use sign_with_factor_source_or_sources_outcome::*;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,10 +2,10 @@ mod factor_sources_of_kind;
 mod hd_signature;
 mod hd_signature_input;
 mod invalid_transaction_if_skipped;
+mod new_methods_on_sargon_types;
 mod owned_types;
 mod sargon_types;
 mod sign_with_factor_source_or_sources_outcome;
-mod new_methods_on_sargon_types;
 
 pub(crate) use factor_sources_of_kind::*;
 pub use hd_signature::*;
@@ -13,5 +13,4 @@ pub use hd_signature_input::*;
 pub use invalid_transaction_if_skipped::*;
 pub use owned_types::*;
 pub use sargon_types::*;
-pub use new_methods_on_sargon_types::*;
 pub use sign_with_factor_source_or_sources_outcome::*;

--- a/src/types/new_methods_on_sargon_types.rs
+++ b/src/types/new_methods_on_sargon_types.rs
@@ -1,0 +1,17 @@
+use crate::prelude::*;
+
+impl AccountOrPersona {
+    pub fn address(&self) -> AddressOfAccountOrPersona {
+        match self {
+            Self::AccountEntity(a) => a.address.into(),
+            Self::PersonaEntity(p) => p.address.into(),
+        }
+    }
+
+    pub fn security_state(&self) -> EntitySecurityState {
+        match self {
+            Self::AccountEntity(a) => a.security_state.clone(),
+            Self::PersonaEntity(p) => p.security_state.clone(),
+        }
+    }
+}

--- a/src/types/new_methods_on_sargon_types.rs
+++ b/src/types/new_methods_on_sargon_types.rs
@@ -30,3 +30,20 @@ impl TransactionIntent {
         self.manifest.summary()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_address() {
+        let account = AccountOrPersona::from(Account::sample());
+        assert_eq!(account.address().to_string(), "acco_Alice")
+    }
+
+    #[test]
+    fn persona_address() {
+        let persona = AccountOrPersona::from(Persona::sample());
+        assert_eq!(persona.address().to_string(), "ident_Alice")
+    }
+}

--- a/src/types/new_methods_on_sargon_types.rs
+++ b/src/types/new_methods_on_sargon_types.rs
@@ -17,8 +17,11 @@ impl AccountOrPersona {
 }
 
 impl Profile {
-    pub fn persona_by_address(&self, _address: IdentityAddress) -> Result<Persona> {
-        todo!()
+    pub fn persona_by_address(&self, address: IdentityAddress) -> Result<Persona> {
+        self.personas
+            .get(&address)
+            .ok_or(CommonError::UnknownPersona)
+            .cloned()
     }
 }
 

--- a/src/types/new_methods_on_sargon_types.rs
+++ b/src/types/new_methods_on_sargon_types.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 impl AccountOrPersona {
     pub fn address(&self) -> AddressOfAccountOrPersona {
         match self {
-            Self::AccountEntity(a) => a.address.into(),
-            Self::PersonaEntity(p) => p.address.into(),
+            Self::AccountEntity(a) => a.address().clone(),
+            Self::PersonaEntity(p) => p.address().clone(),
         }
     }
 

--- a/src/types/new_methods_on_sargon_types.rs
+++ b/src/types/new_methods_on_sargon_types.rs
@@ -15,3 +15,15 @@ impl AccountOrPersona {
         }
     }
 }
+
+impl Profile {
+    pub fn persona_by_address(&self, _address: IdentityAddress) -> Result<Persona> {
+        todo!()
+    }
+}
+
+impl TransactionIntent {
+    pub fn manifest_summary(&self) -> ManifestSummary {
+        self.manifest.summary()
+    }
+}

--- a/src/types/owned_types/owned.rs
+++ b/src/types/owned_types/owned.rs
@@ -21,9 +21,6 @@ impl<T: HasSampleValues> HasSampleValues for Owned<T> {
         Self::new(AddressOfAccountOrPersona::sample(), T::sample())
     }
     fn sample_other() -> Self {
-        Self::new(
-            AddressOfAccountOrPersona::sample_other(),
-            T::sample_other(),
-        )
+        Self::new(AddressOfAccountOrPersona::sample_other(), T::sample_other())
     }
 }

--- a/src/types/owned_types/owned.rs
+++ b/src/types/owned_types/owned.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// Some value with a known owner - an account or persona.
 #[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
-#[debug("{:?}: {:?}", owner, value)]
+#[debug("{:#?}: {:#?}", owner, value)]
 pub struct Owned<T> {
     /// The known owner - an account or persona - of `value`.
     pub owner: AddressOfAccountOrPersona,

--- a/src/types/owned_types/owned.rs
+++ b/src/types/owned_types/owned.rs
@@ -5,24 +5,24 @@ use crate::prelude::*;
 #[debug("{:?}: {:?}", owner, value)]
 pub struct Owned<T> {
     /// The known owner - an account or persona - of `value`.
-    pub owner: AccountAddressOrIdentityAddress,
+    pub owner: AddressOfAccountOrPersona,
     /// Some value known to be owned by `owner` - an account or persona.
     pub value: T,
 }
 
 impl<T> Owned<T> {
-    pub fn new(owner: AccountAddressOrIdentityAddress, value: T) -> Self {
+    pub fn new(owner: AddressOfAccountOrPersona, value: T) -> Self {
         Self { owner, value }
     }
 }
 
 impl<T: HasSampleValues> HasSampleValues for Owned<T> {
     fn sample() -> Self {
-        Self::new(AccountAddressOrIdentityAddress::sample(), T::sample())
+        Self::new(AddressOfAccountOrPersona::sample(), T::sample())
     }
     fn sample_other() -> Self {
         Self::new(
-            AccountAddressOrIdentityAddress::sample_other(),
+            AddressOfAccountOrPersona::sample_other(),
             T::sample_other(),
         )
     }

--- a/src/types/owned_types/owned_factor_instance.rs
+++ b/src/types/owned_types/owned_factor_instance.rs
@@ -8,7 +8,7 @@ pub type OwnedFactorInstance = Owned<FactorInstance>;
 impl OwnedFactorInstance {
     /// Constructs a new `OwnedFactorInstance`.
     pub fn owned_factor_instance(
-        owner: AccountAddressOrIdentityAddress,
+        owner: AddressOfAccountOrPersona,
         factor_instance: FactorInstance,
     ) -> Self {
         Self::new(owner, factor_instance)

--- a/src/types/owned_types/owned_factor_instance.rs
+++ b/src/types/owned_types/owned_factor_instance.rs
@@ -2,20 +2,20 @@ use std::borrow::Borrow;
 
 use crate::prelude::*;
 
-/// A `FactorInstance` with a known owner - an account or persona.
-pub type OwnedFactorInstance = Owned<FactorInstance>;
+/// A `HierarchicalDeterministicFactorInstance` with a known owner - an account or persona.
+pub type OwnedFactorInstance = Owned<HierarchicalDeterministicFactorInstance>;
 
 impl OwnedFactorInstance {
     /// Constructs a new `OwnedFactorInstance`.
     pub fn owned_factor_instance(
         owner: AddressOfAccountOrPersona,
-        factor_instance: FactorInstance,
+        factor_instance: HierarchicalDeterministicFactorInstance,
     ) -> Self {
         Self::new(owner, factor_instance)
     }
 
-    /// The owned `FactorInstance`, the value of this `OwnedFactorInstance`.
-    pub fn factor_instance(&self) -> &FactorInstance {
+    /// The owned `HierarchicalDeterministicFactorInstance`, the value of this `OwnedFactorInstance`.
+    pub fn factor_instance(&self) -> &HierarchicalDeterministicFactorInstance {
         &self.value
     }
 
@@ -27,7 +27,7 @@ impl OwnedFactorInstance {
     }
 }
 
-impl From<OwnedFactorInstance> for FactorInstance {
+impl From<OwnedFactorInstance> for HierarchicalDeterministicFactorInstance {
     fn from(value: OwnedFactorInstance) -> Self {
         value.value
     }

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -464,6 +464,52 @@ pub enum AccountOrPersona {
     PersonaEntity(Persona),
 }
 
+pub trait IsEntity: Into<AccountOrPersona> + Clone {
+    type Address: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier;
+
+    fn new(name: impl AsRef<str>, security_state: impl Into<EntitySecurityState>) -> Self;
+
+    fn entity_address(&self) -> Self::Address;
+    fn kind() -> CAP26EntityKind {
+        Self::Address::entity_kind()
+    }
+    fn security_state(&self) -> EntitySecurityState;
+    fn address(&self) -> AddressOfAccountOrPersona {
+        self.entity_address().clone().into()
+    }
+    fn e0() -> Self;
+    fn e1() -> Self;
+    fn e2() -> Self;
+    fn e3() -> Self;
+    fn e4() -> Self;
+    fn e5() -> Self;
+    fn e6() -> Self;
+    fn e7() -> Self;
+
+    fn securified_mainnet(
+        index: u32,
+        name: impl AsRef<str>,
+        make_matrix: fn(u32) -> MatrixOfFactorInstances,
+    ) -> Self {
+        Self::new(name, make_matrix(index))
+    }
+
+    fn unsecurified_mainnet(
+        index: u32,
+        name: impl AsRef<str>,
+        factor_source_id: FactorSourceID,
+    ) -> Self {
+        Self::new(
+            name,
+            EntitySecurityState::Unsecured(HierarchicalDeterministicFactorInstance::mainnet_tx(
+                Self::kind(),
+                index,
+                factor_source_id,
+            )),
+        )
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
 #[debug("{}", self.address())]
 pub struct AbstractEntity<A: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier> {
@@ -471,7 +517,86 @@ pub struct AbstractEntity<A: Clone + Into<AddressOfAccountOrPersona> + EntityKin
     pub security_state: EntitySecurityState,
 }
 pub type Account = AbstractEntity<AccountAddress>;
+impl IsEntity for Account {
+    fn new(name: impl AsRef<str>, security_state: impl Into<EntitySecurityState>) -> Self {
+        Self {
+            address: AccountAddress::from(name.as_ref().to_owned()),
+            security_state: security_state.into(),
+        }
+    }
+    type Address = AccountAddress;
+    fn security_state(&self) -> EntitySecurityState {
+        self.security_state.clone()
+    }
+    fn entity_address(&self) -> Self::Address {
+        self.address.clone()
+    }
+    fn e0() -> Self {
+        Self::a0()
+    }
+    fn e1() -> Self {
+        Self::a1()
+    }
+    fn e2() -> Self {
+        Self::a2()
+    }
+    fn e3() -> Self {
+        Self::a3()
+    }
+    fn e4() -> Self {
+        Self::a4()
+    }
+    fn e5() -> Self {
+        Self::a5()
+    }
+    fn e6() -> Self {
+        Self::a6()
+    }
+    fn e7() -> Self {
+        Self::a7()
+    }
+}
+
 pub type Persona = AbstractEntity<IdentityAddress>;
+impl IsEntity for Persona {
+    fn new(name: impl AsRef<str>, security_state: impl Into<EntitySecurityState>) -> Self {
+        Self {
+            address: IdentityAddress::from(name.as_ref().to_owned()),
+            security_state: security_state.into(),
+        }
+    }
+    type Address = IdentityAddress;
+    fn security_state(&self) -> EntitySecurityState {
+        self.security_state.clone()
+    }
+    fn entity_address(&self) -> Self::Address {
+        self.address.clone()
+    }
+    fn e0() -> Self {
+        Self::p0()
+    }
+    fn e1() -> Self {
+        Self::p1()
+    }
+    fn e2() -> Self {
+        Self::p2()
+    }
+    fn e3() -> Self {
+        Self::p3()
+    }
+    fn e4() -> Self {
+        Self::p4()
+    }
+    fn e5() -> Self {
+        Self::p5()
+    }
+    fn e6() -> Self {
+        Self::p6()
+    }
+    fn e7() -> Self {
+        Self::p7()
+    }
+}
 
 impl<T: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier> EntityKindSpecifier
     for AbstractEntity<T>
@@ -482,9 +607,6 @@ impl<T: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier> EntityKin
 }
 
 impl<T: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier> AbstractEntity<T> {
-    pub fn entity_address(&self) -> T {
-        self.address.clone()
-    }
     pub fn address(&self) -> AddressOfAccountOrPersona {
         self.address.clone().into()
     }
@@ -542,14 +664,11 @@ impl<T: Clone + Into<AddressOfAccountOrPersona> + EntityKindSpecifier + From<Str
 
     /// mainnet
     pub(crate) fn sample_securified() -> Self {
-        type F = FactorSourceID;
         Self::securified_mainnet(6, "Grace", |idx| {
-            let fi = HierarchicalDeterministicFactorInstance::f(idx);
-            MatrixOfFactorInstances::new(
-                [F::fs0(), F::fs3(), F::fs5()].map(&fi),
-                2,
-                [F::fs1(), F::fs4()].map(&fi),
-            )
+            MatrixOfFactorInstances::m6(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
         })
     }
 

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -128,11 +128,11 @@ pub type DerivationIndex = u32;
 
 #[repr(u8)]
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
-pub enum KeyKind {
+pub enum CAP26KeyKind {
     T9n,
     Rola,
 }
-impl KeyKind {
+impl CAP26KeyKind {
     fn discriminant(&self) -> u8 {
         core::intrinsics::discriminant_value(self)
     }
@@ -167,7 +167,7 @@ impl EntityKind {
 pub struct DerivationPath {
     pub network_id: NetworkID,
     pub entity_kind: EntityKind,
-    pub key_kind: KeyKind,
+    pub key_kind: CAP26KeyKind,
     pub index: DerivationIndex,
 }
 
@@ -175,7 +175,7 @@ impl DerivationPath {
     pub fn new(
         network_id: NetworkID,
         entity_kind: EntityKind,
-        key_kind: KeyKind,
+        key_kind: CAP26KeyKind,
         index: DerivationIndex,
     ) -> Self {
         Self {
@@ -186,7 +186,7 @@ impl DerivationPath {
         }
     }
     pub fn account_tx(network_id: NetworkID, index: DerivationIndex) -> Self {
-        Self::new(network_id, EntityKind::Account, KeyKind::T9n, index)
+        Self::new(network_id, EntityKind::Account, CAP26KeyKind::T9n, index)
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -256,6 +256,7 @@ pub struct HierarchicalDeterministicFactorInstance {
 }
 
 impl HierarchicalDeterministicFactorInstance {
+    #[allow(unused)]
     fn debug_str(&self) -> String {
         format!(
             "factor_source_id: {:#?}, derivation_path: {:#?}",

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -47,7 +47,7 @@ pub struct FactorSource {
 }
 
 impl FactorSource {
-    pub fn kind(&self) -> FactorSourceKind {
+    pub fn factor_source_kind(&self) -> FactorSourceKind {
         self.id.kind
     }
     pub fn new(kind: FactorSourceKind) -> Self {
@@ -83,7 +83,7 @@ impl PartialOrd for FactorSource {
 }
 impl Ord for FactorSource {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.kind().cmp(&other.kind()) {
+        match self.factor_source_kind().cmp(&other.factor_source_kind()) {
             core::cmp::Ordering::Equal => {}
             ord => return ord,
         }

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -612,19 +612,40 @@ impl HasSampleValues for IntentHash {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct TransactionIntent {
-    /// In Sargon we are gonna do:
-    /// ```[no_compile]
-    /// fn map(transaction_manifest: TransactionManifest, profile: Profile) -> Result<TXToSign> {
-    /// let summary: ManifestSummary = transaction_intent.manifest.summary();
-    /// let mut addresses_of_entities_requiring_auth: IndexSet<AddressOfAccountOrPersona> = IndexSet::new();
-    /// addresses_of_entities_requiring_auth.extend(summary.addresses_of_accounts_requiring_auth.into_iter().map(AddressOfAccountOrPersona::from).collect());
-    /// addresses_of_entities_requiring_auth.extend(summary.addresses_of_personas_requiring_auth.into_iter().map(AddressOfAccountOrPersona::from).collect());
-    /// let entities
-    /// }
+pub struct TransactionManifest {
+    addresses_of_accounts_requiring_auth: Vec<AccountAddress>,
+    addresses_of_personas_requiring_auth: Vec<IdentityAddress>,
+}
 
-    /// ```
-    pub(crate) tx_to_sign: TXToSign,
+impl TransactionManifest {
+    pub fn summary(&self) -> ManifestSummary {
+        ManifestSummary {
+            addresses_of_accounts_requiring_auth: self.addresses_of_accounts_requiring_auth.clone(),
+            addresses_of_personas_requiring_auth: self.addresses_of_personas_requiring_auth.clone(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TransactionIntent {
+    pub(crate) manifest: TransactionManifest,
+}
+
+pub struct ManifestSummary {
+    pub addresses_of_accounts_requiring_auth: Vec<AccountAddress>,
+    pub addresses_of_personas_requiring_auth: Vec<IdentityAddress>,
+}
+
+pub struct Profile {
+    pub accounts: HashMap<AccountAddress, Account>,
+}
+impl Profile {
+    pub fn account_by_address(&self, address: AccountAddress) -> Result<Account> {
+        self.accounts
+            .get(&address)
+            .ok_or(CommonError::UnknownAccount)
+            .cloned()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
@@ -677,4 +698,7 @@ pub enum CommonError {
 
     #[error("Empty FactorSources list")]
     FactorSourcesOfKindEmptyFactors,
+
+    #[error("Unknown account")]
+    UnknownAccount,
 }

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -152,12 +152,12 @@ impl NetworkID {
 
 #[repr(u8)]
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
-pub enum EntityKind {
+pub enum CAP26EntityKind {
     Account,
     Identity,
 }
 
-impl EntityKind {
+impl CAP26EntityKind {
     fn discriminant(&self) -> u8 {
         core::intrinsics::discriminant_value(self)
     }
@@ -166,7 +166,7 @@ impl EntityKind {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DerivationPath {
     pub network_id: NetworkID,
-    pub entity_kind: EntityKind,
+    pub entity_kind: CAP26EntityKind,
     pub key_kind: CAP26KeyKind,
     pub index: DerivationIndex,
 }
@@ -174,7 +174,7 @@ pub struct DerivationPath {
 impl DerivationPath {
     pub fn new(
         network_id: NetworkID,
-        entity_kind: EntityKind,
+        entity_kind: CAP26EntityKind,
         key_kind: CAP26KeyKind,
         index: DerivationIndex,
     ) -> Self {
@@ -186,7 +186,12 @@ impl DerivationPath {
         }
     }
     pub fn account_tx(network_id: NetworkID, index: DerivationIndex) -> Self {
-        Self::new(network_id, EntityKind::Account, CAP26KeyKind::T9n, index)
+        Self::new(
+            network_id,
+            CAP26EntityKind::Account,
+            CAP26KeyKind::T9n,
+            index,
+        )
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -249,12 +249,12 @@ impl HierarchicalDeterministicPublicKey {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
-pub struct FactorInstance {
-    pub hd_public_key: HierarchicalDeterministicPublicKey,
+pub struct HierarchicalDeterministicFactorInstance {
     pub factor_source_id: FactorSourceID,
+    pub hd_public_key: HierarchicalDeterministicPublicKey,
 }
 
-impl FactorInstance {
+impl HierarchicalDeterministicFactorInstance {
     pub fn new(
         hd_public_key: HierarchicalDeterministicPublicKey,
         factor_source_id: FactorSourceID,
@@ -300,7 +300,7 @@ impl FactorInstance {
     }
 }
 
-impl HasSampleValues for FactorInstance {
+impl HasSampleValues for HierarchicalDeterministicFactorInstance {
     fn sample() -> Self {
         Self::account_mainnet_tx(0, FactorSourceID::sample())
     }
@@ -338,11 +338,11 @@ impl HasSampleValues for Hash {
 
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub enum EntitySecurityState {
-    Unsecured(FactorInstance),
+    Unsecured(HierarchicalDeterministicFactorInstance),
     Securified(MatrixOfFactorInstances),
 }
 impl EntitySecurityState {
-    pub fn all_factor_instances(&self) -> IndexSet<FactorInstance> {
+    pub fn all_factor_instances(&self) -> IndexSet<HierarchicalDeterministicFactorInstance> {
         match self {
             Self::Securified(matrix) => {
                 let mut set = IndexSet::new();
@@ -470,7 +470,7 @@ impl Account {
     pub(crate) fn sample_securified() -> Self {
         type F = FactorSourceID;
         Self::securified_mainnet(6, "Grace", |idx| {
-            let fi = FactorInstance::f(idx);
+            let fi = HierarchicalDeterministicFactorInstance::f(idx);
             MatrixOfFactorInstances::new(
                 [F::fs0(), F::fs3(), F::fs5()].map(&fi),
                 2,
@@ -501,10 +501,12 @@ impl Account {
     ) -> Self {
         Self::new(
             name,
-            EntitySecurityState::Unsecured(FactorInstance::account_mainnet_tx(
-                index,
-                factor_source_id,
-            )),
+            EntitySecurityState::Unsecured(
+                HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                    index,
+                    factor_source_id,
+                ),
+            ),
         )
     }
 }
@@ -567,13 +569,13 @@ where
     }
 }
 
-pub type MatrixOfFactorInstances = MatrixOfFactors<FactorInstance>;
+pub type MatrixOfFactorInstances = MatrixOfFactors<HierarchicalDeterministicFactorInstance>;
 pub type MatrixOfFactorSources = MatrixOfFactors<FactorSource>;
 
 /// For unsecurified entities we map single factor -> single threshold factor.
 /// Which is used by ROLA.
-impl From<FactorInstance> for MatrixOfFactorInstances {
-    fn from(value: FactorInstance) -> Self {
+impl From<HierarchicalDeterministicFactorInstance> for MatrixOfFactorInstances {
+    fn from(value: HierarchicalDeterministicFactorInstance) -> Self {
         Self {
             threshold: 1,
             threshold_factors: vec![value],
@@ -648,7 +650,7 @@ impl Signature {
     /// deterministic manner.
     pub fn produced_by(
         intent_hash: IntentHash,
-        factor_instance: impl Into<FactorInstance>,
+        factor_instance: impl Into<HierarchicalDeterministicFactorInstance>,
     ) -> Self {
         let factor_instance = factor_instance.into();
 

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, str::FromStr};
+use std::marker::PhantomData;
 
 use crate::prelude::*;
 
@@ -704,16 +704,19 @@ impl ManifestSummary {
 }
 
 pub struct Profile {
+    pub factor_sources: IndexSet<FactorSource>,
     pub accounts: HashMap<AccountAddress, Account>,
     pub personas: HashMap<IdentityAddress, Persona>,
 }
 
 impl Profile {
     pub fn new<'a, 'p>(
+        factor_sources: IndexSet<FactorSource>,
         accounts: impl IntoIterator<Item = &'a Account>,
         personas: impl IntoIterator<Item = &'p Persona>,
     ) -> Self {
         Self {
+            factor_sources,
             accounts: accounts
                 .into_iter()
                 .map(|a| (a.entity_address(), a.clone()))

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -248,13 +248,21 @@ impl HierarchicalDeterministicPublicKey {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
+#[debug("{}", self.debug_str())]
 pub struct HierarchicalDeterministicFactorInstance {
     pub factor_source_id: FactorSourceID,
     pub public_key: HierarchicalDeterministicPublicKey,
 }
 
 impl HierarchicalDeterministicFactorInstance {
+    fn debug_str(&self) -> String {
+        format!(
+            "factor_source_id: {:?}, derivation_path: {:?}",
+            self.factor_source_id, self.public_key.derivation_path
+        )
+    }
+
     pub fn new(
         public_key: HierarchicalDeterministicPublicKey,
         factor_source_id: FactorSourceID,

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -251,22 +251,22 @@ impl HierarchicalDeterministicPublicKey {
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub struct HierarchicalDeterministicFactorInstance {
     pub factor_source_id: FactorSourceID,
-    pub hd_public_key: HierarchicalDeterministicPublicKey,
+    pub public_key: HierarchicalDeterministicPublicKey,
 }
 
 impl HierarchicalDeterministicFactorInstance {
     pub fn new(
-        hd_public_key: HierarchicalDeterministicPublicKey,
+        public_key: HierarchicalDeterministicPublicKey,
         factor_source_id: FactorSourceID,
     ) -> Self {
         Self {
-            hd_public_key,
+            public_key,
             factor_source_id,
         }
     }
 
-    pub fn path(&self) -> DerivationPath {
-        self.hd_public_key.derivation_path.clone()
+    pub fn derivation_path(&self) -> DerivationPath {
+        self.public_key.derivation_path.clone()
     }
 
     pub fn mocked_with(derivation_path: DerivationPath, factor_source_id: &FactorSourceID) -> Self {
@@ -292,11 +292,7 @@ impl HierarchicalDeterministicFactorInstance {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        [
-            self.hd_public_key.to_bytes(),
-            self.factor_source_id.to_bytes(),
-        ]
-        .concat()
+        [self.public_key.to_bytes(), self.factor_source_id.to_bytes()].concat()
     }
 }
 

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -611,24 +611,20 @@ impl HasSampleValues for IntentHash {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TransactionIntent {
-    pub intent_hash: IntentHash,
-    pub entities_requiring_auth: Vec<AccountOrPersona>, // should be a set but Sets are not `Hash`.
-}
+    /// In Sargon we are gonna do:
+    /// ```[no_compile]
+    /// fn map(transaction_manifest: TransactionManifest, profile: Profile) -> Result<TXToSign> {
+    /// let summary: ManifestSummary = transaction_intent.manifest.summary();
+    /// let mut addresses_of_entities_requiring_auth: IndexSet<AddressOfAccountOrPersona> = IndexSet::new();
+    /// addresses_of_entities_requiring_auth.extend(summary.addresses_of_accounts_requiring_auth.into_iter().map(AddressOfAccountOrPersona::from).collect());
+    /// addresses_of_entities_requiring_auth.extend(summary.addresses_of_personas_requiring_auth.into_iter().map(AddressOfAccountOrPersona::from).collect());
+    /// let entities
+    /// }
 
-impl TransactionIntent {
-    pub fn new(
-        entities_requiring_auth: impl IntoIterator<Item = impl Into<AccountOrPersona>>,
-    ) -> Self {
-        Self {
-            intent_hash: IntentHash::generate(),
-            entities_requiring_auth: entities_requiring_auth
-                .into_iter()
-                .map(|i| i.into())
-                .collect_vec(),
-        }
-    }
+    /// ```
+    pub(crate) tx_to_sign: TXToSign,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -42,7 +42,7 @@ impl HasSampleValues for FactorSourceID {
 }
 
 #[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
-#[debug("{:?}", id)]
+#[debug("{:#?}", id)]
 pub struct FactorSource {
     pub last_used: SystemTime,
     id: FactorSourceID,
@@ -258,7 +258,7 @@ pub struct HierarchicalDeterministicFactorInstance {
 impl HierarchicalDeterministicFactorInstance {
     fn debug_str(&self) -> String {
         format!(
-            "factor_source_id: {:?}, derivation_path: {:?}",
+            "factor_source_id: {:#?}, derivation_path: {:#?}",
             self.factor_source_id, self.public_key.derivation_path
         )
     }
@@ -365,7 +365,8 @@ impl From<MatrixOfFactorInstances> for EntitySecurityState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash, derive_more::Display)]
+#[display("{name}")]
 pub struct AbstractAddress<T> {
     phantom: PhantomData<T>,
     pub name: String,
@@ -401,12 +402,18 @@ pub struct IdentityAddressTag;
 pub type AccountAddress = AbstractAddress<AccountAddressTag>;
 pub type IdentityAddress = AbstractAddress<IdentityAddressTag>;
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Display)]
 pub enum AddressOfAccountOrPersona {
+    #[display("acco_{_0}")]
     Account(AccountAddress),
+    #[display("ident_{_0}")]
     Identity(IdentityAddress),
 }
-
+impl std::fmt::Debug for AddressOfAccountOrPersona {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
 impl HasSampleValues for AddressOfAccountOrPersona {
     fn sample() -> Self {
         Self::Account(AccountAddress::sample())
@@ -422,7 +429,8 @@ pub enum AccountOrPersona {
     PersonaEntity(Persona),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
+#[debug("{}", self.address())]
 pub struct AbstractEntity<A: Clone + Into<AddressOfAccountOrPersona>> {
     address: A,
     pub security_state: EntitySecurityState,
@@ -601,7 +609,8 @@ pub trait HasSampleValues {
     fn sample_other() -> Self;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash, Getters)]
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, Getters, derive_more::Debug)]
+#[debug("TXID({:#?})", hash.id.to_string()[..6].to_owned())]
 pub struct IntentHash {
     hash: Hash,
 }

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -838,12 +838,16 @@ impl TransactionManifest {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct TransactionIntent {
+    pub intent_hash: IntentHash,
     pub(crate) manifest: TransactionManifest,
 }
 
 impl TransactionIntent {
     fn with(manifest: TransactionManifest) -> Self {
-        Self { manifest }
+        Self {
+            manifest,
+            intent_hash: IntentHash::generate(),
+        }
     }
     pub fn new(
         addresses_of_accounts_requiring_auth: impl IntoIterator<Item = AccountAddress>,

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -43,10 +43,13 @@ impl HasSampleValues for FactorSourceID {
 #[debug("{:?}", id)]
 pub struct FactorSource {
     pub last_used: SystemTime,
-    pub id: FactorSourceID,
+    id: FactorSourceID,
 }
 
 impl FactorSource {
+    pub fn factor_source_id(&self) -> FactorSourceID {
+        self.id
+    }
     pub fn factor_source_kind(&self) -> FactorSourceKind {
         self.id.kind
     }

--- a/src/types/sign_with_factor_source_or_sources_outcome.rs
+++ b/src/types/sign_with_factor_source_or_sources_outcome.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 pub enum SignWithFactorSourceOrSourcesOutcome<T> {
     /// The user successfully signed with the factor source(s), the associated
     /// value contains the produces signatures and any relevant metadata.
-    #[debug("Signed: {:?}", produced_signatures)]
+    #[debug("Signed: {:#?}", produced_signatures)]
     Signed { produced_signatures: T },
 
     /// The user skipped signing with the factor sources with ids

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -625,10 +625,7 @@ mod signing_tests {
                 let collector = SignaturesCollector::test_prudent([tx.clone()]);
                 let signature = &collector.collect_signatures().await.all_signatures()[0];
                 assert_eq!(signature.intent_hash(), &tx.intent_hash);
-                assert_eq!(
-                    signature.derivation_path().entity_kind,
-                    CAP26EntityKind::Account
-                );
+                assert_eq!(signature.derivation_path().entity_kind, E::kind());
             }
 
             async fn prudent_user_single_tx_e0_assert_correct_owner_has_signed<E: IsEntity>() {
@@ -1132,6 +1129,181 @@ mod signing_tests {
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a7() {
+                    lazy_always_skip_user_e7::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn failure() {
+                    failure_e0::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx(
+                ) {
+                    building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx_e4::<E>()
+                        .await
+                }
+
+                #[actix_rt::test]
+                async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx(
+                ) {
+                    building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx_e4::<E>().await
+                }
+            }
+
+            mod persona {
+                use super::*;
+                type E = Persona;
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p0() {
+                    prudent_user_single_tx_e0::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p0_assert_correct_intent_hash_is_signed() {
+                    prudent_user_single_tx_e0_assert_correct_intent_hash_is_signed::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p0_assert_correct_owner_has_signed() {
+                    prudent_user_single_tx_e0_assert_correct_owner_has_signed::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p0_assert_correct_owner_factor_instance_signed() {
+                    prudent_user_single_tx_e0_assert_correct_owner_factor_instance_signed::<E>()
+                        .await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p1() {
+                    prudent_user_single_tx_e1::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p2() {
+                    prudent_user_single_tx_e2::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p3() {
+                    prudent_user_single_tx_e3::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p4() {
+                    prudent_user_single_tx_e4::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p5() {
+                    prudent_user_single_tx_e5::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p6() {
+                    prudent_user_single_tx_e6::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn prudent_user_single_tx_p7() {
+                    prudent_user_single_tx_e7::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_single_tx_p0() {
+                    lazy_sign_minimum_user_single_tx_e0::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_single_tx_p1() {
+                    lazy_sign_minimum_user_single_tx_e1::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_single_tx_p2() {
+                    lazy_sign_minimum_user_single_tx_e2::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p3() {
+                    lazy_sign_minimum_user_e3::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p4() {
+                    lazy_sign_minimum_user_e4::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p5() {
+                    lazy_sign_minimum_user_e5::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p6() {
+                    lazy_sign_minimum_user_e6::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p7() {
+                    lazy_sign_minimum_user_e7::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_user_p5_last_factor_used() {
+                    lazy_sign_minimum_user_e5_last_factor_used::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device_for_account(
+                ) {
+                    lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device_for_entity::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_single_tx_p0() {
+                    lazy_always_skip_user_single_tx_e0::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn fail_get_skipped_p0() {
+                    fail_get_skipped_e0::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_single_tx_p1() {
+                    lazy_always_skip_user_single_tx_e1::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_single_tx_p2() {
+                    lazy_always_skip_user_single_tx_e2::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_p3() {
+                    lazy_always_skip_user_e3::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_p4() {
+                    lazy_always_skip_user_e4::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_p5() {
+                    lazy_always_skip_user_e5::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_p6() {
+                    lazy_always_skip_user_e6::<E>().await
+                }
+
+                #[actix_rt::test]
+                async fn lazy_always_skip_user_p7() {
                     lazy_always_skip_user_e7::<E>().await
                 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -33,8 +33,8 @@ mod common_tests {
 #[cfg(test)]
 mod key_derivation_tests {
 
+    use super::CAP26EntityKind::*;
     use super::CAP26KeyKind::*;
-    use super::EntityKind::*;
     use super::NetworkID::*;
     use super::*;
 
@@ -360,7 +360,7 @@ mod key_derivation_tests {
             key_space: KeySpace,
             factor_source: &FactorSource,
             network_id: NetworkID,
-            entity_kind: EntityKind,
+            entity_kind: CAP26EntityKind,
             key_kind: CAP26KeyKind,
             expected: Expected,
         ) {
@@ -384,7 +384,7 @@ mod key_derivation_tests {
             async fn test(
                 factor_source: &FactorSource,
                 network_id: NetworkID,
-                entity_kind: EntityKind,
+                entity_kind: CAP26EntityKind,
                 key_kind: CAP26KeyKind,
             ) {
                 do_test(
@@ -422,7 +422,7 @@ mod key_derivation_tests {
             async fn test(
                 factor_source: &FactorSource,
                 network_id: NetworkID,
-                entity_kind: EntityKind,
+                entity_kind: CAP26EntityKind,
                 key_kind: CAP26KeyKind,
             ) {
                 do_test(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -33,8 +33,8 @@ mod common_tests {
 #[cfg(test)]
 mod key_derivation_tests {
 
+    use super::CAP26KeyKind::*;
     use super::EntityKind::*;
-    use super::KeyKind::*;
     use super::NetworkID::*;
     use super::*;
 
@@ -361,7 +361,7 @@ mod key_derivation_tests {
             factor_source: &FactorSource,
             network_id: NetworkID,
             entity_kind: EntityKind,
-            key_kind: KeyKind,
+            key_kind: CAP26KeyKind,
             expected: Expected,
         ) {
             let collector =
@@ -385,7 +385,7 @@ mod key_derivation_tests {
                 factor_source: &FactorSource,
                 network_id: NetworkID,
                 entity_kind: EntityKind,
-                key_kind: KeyKind,
+                key_kind: CAP26KeyKind,
             ) {
                 do_test(
                     KeySpace::Securified,
@@ -403,7 +403,7 @@ mod key_derivation_tests {
             mod account {
                 use super::*;
 
-                async fn each_factor(network_id: NetworkID, key_kind: KeyKind) {
+                async fn each_factor(network_id: NetworkID, key_kind: CAP26KeyKind) {
                     for factor_source in FactorSource::all().iter() {
                         test(factor_source, network_id, Account, key_kind).await
                     }
@@ -423,7 +423,7 @@ mod key_derivation_tests {
                 factor_source: &FactorSource,
                 network_id: NetworkID,
                 entity_kind: EntityKind,
-                key_kind: KeyKind,
+                key_kind: CAP26KeyKind,
             ) {
                 do_test(
                     KeySpace::Unsecurified,
@@ -439,7 +439,7 @@ mod key_derivation_tests {
             mod account {
                 use super::*;
 
-                async fn each_factor(network_id: NetworkID, key_kind: KeyKind) {
+                async fn each_factor(network_id: NetworkID, key_kind: CAP26KeyKind) {
                     for factor_source in FactorSource::all().iter() {
                         test(factor_source, network_id, Account, key_kind).await
                     }
@@ -469,7 +469,7 @@ mod key_derivation_tests {
             mod persona {
                 use super::*;
 
-                async fn each_factor(network_id: NetworkID, key_kind: KeyKind) {
+                async fn each_factor(network_id: NetworkID, key_kind: CAP26KeyKind) {
                     for factor_source in FactorSource::all().iter() {
                         test(factor_source, network_id, Identity, key_kind).await
                     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -74,7 +74,7 @@ mod key_derivation_tests {
                 outcome
                     .all_factors()
                     .into_iter()
-                    .map(|f| f.path())
+                    .map(|f| f.derivation_path())
                     .collect::<IndexSet<_>>(),
                 paths
             );
@@ -102,7 +102,7 @@ mod key_derivation_tests {
                 outcome
                     .all_factors()
                     .into_iter()
-                    .map(|f| f.path())
+                    .map(|f| f.derivation_path())
                     .collect::<IndexSet<_>>(),
                 paths
             );
@@ -141,7 +141,7 @@ mod key_derivation_tests {
                 outcome
                     .all_factors()
                     .into_iter()
-                    .map(|f| f.path())
+                    .map(|f| f.derivation_path())
                     .collect::<IndexSet<_>>(),
                 paths
             );
@@ -329,7 +329,7 @@ mod key_derivation_tests {
                 outcome
                     .all_factors()
                     .into_iter()
-                    .map(|f| f.path())
+                    .map(|f| f.derivation_path())
                     .collect::<IndexSet<_>>(),
                 paths
             );
@@ -373,7 +373,7 @@ mod key_derivation_tests {
             assert_eq!(factors.len(), 1);
             let factor = factors.first().unwrap();
             assert_eq!(
-                factor.path(),
+                factor.derivation_path(),
                 DerivationPath::new(network_id, entity_kind, key_kind, expected.index)
             );
             assert_eq!(factor.factor_source_id, factor_source.factor_source_id());

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -741,11 +741,12 @@ mod signing_tests {
     async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
             TransactionIntent::new([Account::securified_mainnet(0, "all override", |idx| {
-                MatrixOfFactorInstances::override_only(
-                    FactorSource::all()
-                        .into_iter()
-                        .map(|f| FactorInstance::account_mainnet_tx(idx, f.factor_source_id())),
-                )
+                MatrixOfFactorInstances::override_only(FactorSource::all().into_iter().map(|f| {
+                    HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                        idx,
+                        f.factor_source_id(),
+                    )
+                }))
             })]),
         ]);
         let outcome = collector.collect_signatures().await;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -507,8 +507,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a0()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -517,7 +516,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_intent_hash_is_signed() {
-        let tx = TransactionIntent::new([Account::a0()]);
+        let tx = TXToSign::new([Account::a0()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
         assert_eq!(signature.intent_hash(), &tx.intent_hash);
@@ -526,7 +525,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_has_signed() {
         let account = Account::a0();
-        let tx = TransactionIntent::new([account.clone()]);
+        let tx = TXToSign::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
         assert_eq!(signature.owned_factor_instance().owner, account.address());
@@ -535,7 +534,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_factor_instance_signed() {
         let account = Account::a0();
-        let tx = TransactionIntent::new([account.clone()]);
+        let tx = TXToSign::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
 
@@ -551,8 +550,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a1() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a1()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -561,8 +559,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a2() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a2()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -571,8 +568,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a3() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a3()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -581,8 +577,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a4() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a4()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -591,8 +586,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a5() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a5()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -601,8 +595,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a6() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a6()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -611,8 +604,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a7() {
-        let collector =
-            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a7()])]);
+        let collector = SignaturesCollector::test_prudent([TXToSign::new([Account::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -622,9 +614,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a0() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a0()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a0(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -633,9 +625,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a1() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a1()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a1(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -644,9 +636,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a2() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a2()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a2(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -655,9 +647,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a3() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a3()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a3(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -666,9 +658,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a4() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a4()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a4(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -677,9 +669,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a5()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a5(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -688,9 +680,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a6() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a6()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a6(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -700,9 +692,9 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a7() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::a7()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::a7(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -713,9 +705,9 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5_last_factor_used() {
         let entity = Account::a5();
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([entity.clone()]),
-        ]);
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            entity.clone(),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -739,16 +731,16 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device() {
-        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Account::securified_mainnet(0, "all override", |idx| {
+        let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([TXToSign::new([
+            Account::securified_mainnet(0, "all override", |idx| {
                 MatrixOfFactorInstances::override_only(FactorSource::all().into_iter().map(|f| {
                     HierarchicalDeterministicFactorInstance::account_mainnet_tx(
                         idx,
                         f.factor_source_id(),
                     )
                 }))
-            })]),
-        ]);
+            }),
+        ])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -767,7 +759,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a0() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a0()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -778,7 +770,7 @@ mod signing_tests {
     async fn fail_get_skipped() {
         let failing = IndexSet::<_>::from_iter([FactorSourceID::fs0()]);
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Account::a0()])],
+            [TXToSign::new([Account::a0()])],
             SimulatedFailures::with_simulated_failures(failing.clone()),
         );
         let outcome = collector.collect_signatures().await;
@@ -790,7 +782,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a1() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a1()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -800,7 +792,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a2() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a2()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -810,7 +802,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a3() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a3()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -820,7 +812,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a4() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a4()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -830,7 +822,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a5() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a5()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -840,7 +832,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a6() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a6()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -850,7 +842,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a7() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a7()])]);
+            SignaturesCollector::test_lazy_always_skip([TXToSign::new([Account::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -860,7 +852,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn failure() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Account::a0()])],
+            [TXToSign::new([Account::a0()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs0()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -870,7 +862,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Account::a4()])],
+            [TXToSign::new([Account::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -888,7 +880,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Account::a4()])],
+            [TXToSign::new([Account::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -569,7 +569,32 @@ mod signing_tests {
             use super::*;
 
             #[actix_rt::test]
-            async fn prudent_user_single_tx_two_accounts_a0_a1() {
+            async fn prudent_user_single_tx_two_accounts_same_factor_source() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([
+                    Account::unsecurified_mainnet(0, "A0", FactorSourceID::fs0()),
+                    Account::unsecurified_mainnet(1, "A1", FactorSourceID::fs0()),
+                ])]);
+
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 2);
+                assert_eq!(
+                    signatures
+                        .into_iter()
+                        .map(|s| s.derivation_path())
+                        .collect::<HashSet<_>>(),
+                    [
+                        DerivationPath::account_tx(NetworkID::Mainnet, 0),
+                        DerivationPath::account_tx(NetworkID::Mainnet, 1),
+                    ]
+                    .into_iter()
+                    .collect::<HashSet<_>>()
+                )
+            }
+
+            #[actix_rt::test]
+            async fn prudent_user_single_tx_two_accounts_different_factor_sources() {
                 let collector = SignaturesCollector::test_prudent([TXToSign::new([
                     Account::a0(),
                     Account::a1(),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -609,428 +609,548 @@ mod signing_tests {
         }
 
         mod single_entity {
+
             use super::*;
+
+            async fn prudent_user_single_tx_e0<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e0()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e0_assert_correct_intent_hash_is_signed<E: IsEntity>() {
+                let tx = TXToSign::new([E::e0()]);
+                let collector = SignaturesCollector::test_prudent([tx.clone()]);
+                let signature = &collector.collect_signatures().await.all_signatures()[0];
+                assert_eq!(signature.intent_hash(), &tx.intent_hash);
+                assert_eq!(
+                    signature.derivation_path().entity_kind,
+                    CAP26EntityKind::Account
+                );
+            }
+
+            async fn prudent_user_single_tx_e0_assert_correct_owner_has_signed<E: IsEntity>() {
+                let entity = E::e0();
+                let tx = TXToSign::new([entity.clone()]);
+                let collector = SignaturesCollector::test_prudent([tx.clone()]);
+                let signature = &collector.collect_signatures().await.all_signatures()[0];
+                assert_eq!(signature.owned_factor_instance().owner, entity.address());
+            }
+
+            async fn prudent_user_single_tx_e0_assert_correct_owner_factor_instance_signed<
+                E: IsEntity,
+            >() {
+                let entity = E::e0();
+                let tx = TXToSign::new([entity.clone()]);
+                let collector = SignaturesCollector::test_prudent([tx.clone()]);
+                let signature = &collector.collect_signatures().await.all_signatures()[0];
+
+                assert_eq!(
+                    signature.owned_factor_instance().factor_instance(),
+                    entity
+                        .security_state()
+                        .all_factor_instances()
+                        .first()
+                        .unwrap()
+                );
+            }
+
+            async fn prudent_user_single_tx_e1<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e1()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e2<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e2()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e3<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e3()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e4<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e4()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 2);
+            }
+
+            async fn prudent_user_single_tx_e5<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e5()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e6<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e6()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn prudent_user_single_tx_e7<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([E::e7()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+
+                assert_eq!(signatures.len(), 5);
+            }
+
+            async fn lazy_sign_minimum_user_single_tx_e0<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e0()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn lazy_sign_minimum_user_single_tx_e1<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e1()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn lazy_sign_minimum_user_single_tx_e2<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e2()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn lazy_sign_minimum_user_e3<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e3()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn lazy_sign_minimum_user_e4<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e4()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 2);
+            }
+
+            async fn lazy_sign_minimum_user_e5<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e5()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+            }
+
+            async fn lazy_sign_minimum_user_e6<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e6()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+
+                assert_eq!(signatures.len(), 2);
+            }
+
+            async fn lazy_sign_minimum_user_e7<E: IsEntity>() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::e7()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+
+                assert_eq!(signatures.len(), 5);
+            }
+
+            async fn lazy_sign_minimum_user_e5_last_factor_used<E: IsEntity>() {
+                let entity = E::e5();
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([entity.clone()]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+
+                let signature = &signatures[0];
+
+                assert_eq!(
+                    signature
+                        .owned_factor_instance()
+                        .factor_instance()
+                        .factor_source_id,
+                    FactorSourceID::fs4()
+                );
+
+                assert_eq!(
+                    outcome.skipped_factor_sources(),
+                    IndexSet::just(FactorSourceID::fs1())
+                )
+            }
+
+            async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device_for_entity<
+                E: IsEntity,
+            >() {
+                let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
+                    TXToSign::new([E::securified_mainnet(0, "all override", |idx| {
+                        MatrixOfFactorInstances::override_only(FactorSource::all().into_iter().map(
+                            |f| {
+                                HierarchicalDeterministicFactorInstance::mainnet_tx_account(
+                                    idx,
+                                    f.factor_source_id(),
+                                )
+                            },
+                        ))
+                    })]),
+                ]);
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 1);
+                let signature = &signatures[0];
+                assert_eq!(
+                    signature
+                        .owned_factor_instance()
+                        .factor_instance()
+                        .factor_source_id
+                        .kind,
+                    FactorSourceKind::Device
+                );
+            }
+
+            async fn lazy_always_skip_user_single_tx_e0<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e0()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn fail_get_skipped_e0<E: IsEntity>() {
+                let failing = IndexSet::<_>::from_iter([FactorSourceID::fs0()]);
+                let collector = SignaturesCollector::test_prudent_with_failures(
+                    [TXToSign::new([E::e0()])],
+                    SimulatedFailures::with_simulated_failures(failing.clone()),
+                );
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let skipped = outcome.skipped_factor_sources();
+                assert_eq!(skipped, failing);
+            }
+
+            async fn lazy_always_skip_user_single_tx_e1<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e1()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_single_tx_e2<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e2()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_e3<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e3()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_e4<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e4()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_e5<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e5()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_e6<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e6()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn lazy_always_skip_user_e7<E: IsEntity>() {
+                let collector =
+                    SignaturesCollector::test_lazy_always_skip([TXToSign::new([E::e7()])]);
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert!(signatures.is_empty());
+            }
+
+            async fn failure_e0<E: IsEntity>() {
+                let collector = SignaturesCollector::test_prudent_with_failures(
+                    [TXToSign::new([E::e0()])],
+                    SimulatedFailures::with_simulated_failures([FactorSourceID::fs0()]),
+                );
+                let outcome = collector.collect_signatures().await;
+                assert!(!outcome.successful());
+            }
+
+            async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx_e4<
+                E: IsEntity,
+            >() {
+                let collector = SignaturesCollector::test_prudent_with_failures(
+                    [TXToSign::new([E::e4()])],
+                    SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
+                );
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                assert_eq!(
+                    outcome
+                        .signatures_of_successful_transactions()
+                        .into_iter()
+                        .map(|f| f.factor_source_id())
+                        .collect::<IndexSet<_>>(),
+                    IndexSet::<_>::from_iter([FactorSourceID::fs0(), FactorSourceID::fs5()])
+                );
+            }
+
+            async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx_e4<
+                E: IsEntity,
+            >() {
+                let collector = SignaturesCollector::test_prudent_with_failures(
+                    [TXToSign::new([E::e4()])],
+                    SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
+                );
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                assert_eq!(
+                    outcome.skipped_factor_sources(),
+                    IndexSet::<_>::from_iter([FactorSourceID::fs3()])
+                );
+            }
 
             mod account {
                 use super::*;
+                type E = Account;
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a0() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a0()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e0::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a0_assert_correct_intent_hash_is_signed() {
-                    let tx = TXToSign::new([Account::a0()]);
-                    let collector = SignaturesCollector::test_prudent([tx.clone()]);
-                    let signature = &collector.collect_signatures().await.all_signatures()[0];
-                    assert_eq!(signature.intent_hash(), &tx.intent_hash);
-                    assert_eq!(
-                        signature.derivation_path().entity_kind,
-                        CAP26EntityKind::Account
-                    );
+                    prudent_user_single_tx_e0_assert_correct_intent_hash_is_signed::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a0_assert_correct_owner_has_signed() {
-                    let account = Account::a0();
-                    let tx = TXToSign::new([account.clone()]);
-                    let collector = SignaturesCollector::test_prudent([tx.clone()]);
-                    let signature = &collector.collect_signatures().await.all_signatures()[0];
-                    assert_eq!(signature.owned_factor_instance().owner, account.address());
+                    prudent_user_single_tx_e0_assert_correct_owner_has_signed::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a0_assert_correct_owner_factor_instance_signed() {
-                    let account = Account::a0();
-                    let tx = TXToSign::new([account.clone()]);
-                    let collector = SignaturesCollector::test_prudent([tx.clone()]);
-                    let signature = &collector.collect_signatures().await.all_signatures()[0];
-
-                    assert_eq!(
-                        signature.owned_factor_instance().factor_instance(),
-                        account
-                            .security_state
-                            .all_factor_instances()
-                            .first()
-                            .unwrap()
-                    );
+                    prudent_user_single_tx_e0_assert_correct_owner_factor_instance_signed::<E>()
+                        .await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a1() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a1()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e1::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a2() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a2()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e2::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a3() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a3()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e3::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a4() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a4()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 2);
+                    prudent_user_single_tx_e4::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a5() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a5()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e5::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a6() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a6()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    prudent_user_single_tx_e6::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a7() {
-                    let collector =
-                        SignaturesCollector::test_prudent([TXToSign::new([Account::a7()])]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-
-                    assert_eq!(signatures.len(), 5);
+                    prudent_user_single_tx_e7::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_single_tx_a0() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a0()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    lazy_sign_minimum_user_single_tx_e0::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_single_tx_a1() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a1()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    lazy_sign_minimum_user_single_tx_e1::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_single_tx_a2() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a2()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    lazy_sign_minimum_user_single_tx_e2::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a3() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a3()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    lazy_sign_minimum_user_e3::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a4() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a4()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 2);
+                    lazy_sign_minimum_user_e4::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a5() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a5()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
+                    lazy_sign_minimum_user_e5::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a6() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a6()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-
-                    assert_eq!(signatures.len(), 2);
+                    lazy_sign_minimum_user_e6::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a7() {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::a7()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-
-                    assert_eq!(signatures.len(), 5);
+                    lazy_sign_minimum_user_e7::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_sign_minimum_user_a5_last_factor_used() {
-                    let entity = Account::a5();
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([entity.clone()]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
-
-                    let signature = &signatures[0];
-
-                    assert_eq!(
-                        signature
-                            .owned_factor_instance()
-                            .factor_instance()
-                            .factor_source_id,
-                        FactorSourceID::fs4()
-                    );
-
-                    assert_eq!(
-                        outcome.skipped_factor_sources(),
-                        IndexSet::just(FactorSourceID::fs1())
-                    )
+                    lazy_sign_minimum_user_e5_last_factor_used::<E>().await
                 }
 
                 #[actix_rt::test]
-                async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device(
+                async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device_for_account(
                 ) {
-                    let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-                        TXToSign::new([Account::securified_mainnet(0, "all override", |idx| {
-                            MatrixOfFactorInstances::override_only(
-                                FactorSource::all().into_iter().map(|f| {
-                                    HierarchicalDeterministicFactorInstance::mainnet_tx_account(
-                                        idx,
-                                        f.factor_source_id(),
-                                    )
-                                }),
-                            )
-                        })]),
-                    ]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert_eq!(signatures.len(), 1);
-                    let signature = &signatures[0];
-                    assert_eq!(
-                        signature
-                            .owned_factor_instance()
-                            .factor_instance()
-                            .factor_source_id
-                            .kind,
-                        FactorSourceKind::Device
-                    );
+                    lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device_for_entity::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_single_tx_a0() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a0()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_single_tx_e0::<E>().await
                 }
 
                 #[actix_rt::test]
-                async fn fail_get_skipped() {
-                    let failing = IndexSet::<_>::from_iter([FactorSourceID::fs0()]);
-                    let collector = SignaturesCollector::test_prudent_with_failures(
-                        [TXToSign::new([Account::a0()])],
-                        SimulatedFailures::with_simulated_failures(failing.clone()),
-                    );
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let skipped = outcome.skipped_factor_sources();
-                    assert_eq!(skipped, failing);
+                async fn fail_get_skipped_a0() {
+                    fail_get_skipped_e0::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_single_tx_a1() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a1()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_single_tx_e1::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_single_tx_a2() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a2()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_single_tx_e2::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a3() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a3()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_e3::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a4() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a4()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_e4::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a5() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a5()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_e5::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a6() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a6()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_e6::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn lazy_always_skip_user_a7() {
-                    let collector =
-                        SignaturesCollector::test_lazy_always_skip([TXToSign::new(
-                            [Account::a7()],
-                        )]);
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
-                    let signatures = outcome.all_signatures();
-                    assert!(signatures.is_empty());
+                    lazy_always_skip_user_e7::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn failure() {
-                    let collector = SignaturesCollector::test_prudent_with_failures(
-                        [TXToSign::new([Account::a0()])],
-                        SimulatedFailures::with_simulated_failures([FactorSourceID::fs0()]),
-                    );
-                    let outcome = collector.collect_signatures().await;
-                    assert!(!outcome.successful());
+                    failure_e0::<E>().await
                 }
 
                 #[actix_rt::test]
                 async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx(
                 ) {
-                    let collector = SignaturesCollector::test_prudent_with_failures(
-                        [TXToSign::new([Account::a4()])],
-                        SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
-                    );
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    assert_eq!(
-                        outcome
-                            .signatures_of_successful_transactions()
-                            .into_iter()
-                            .map(|f| f.factor_source_id())
-                            .collect::<IndexSet<_>>(),
-                        IndexSet::<_>::from_iter([FactorSourceID::fs0(), FactorSourceID::fs5()])
-                    );
+                    building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx_e4::<E>()
+                        .await
                 }
 
                 #[actix_rt::test]
                 async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx(
                 ) {
-                    let collector = SignaturesCollector::test_prudent_with_failures(
-                        [TXToSign::new([Account::a4()])],
-                        SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
-                    );
-                    let outcome = collector.collect_signatures().await;
-                    assert!(outcome.successful());
-                    assert_eq!(
-                        outcome.skipped_factor_sources(),
-                        IndexSet::<_>::from_iter([FactorSourceID::fs3()])
-                    );
+                    building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx_e4::<E>().await
                 }
             }
         }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -20,12 +20,12 @@ mod common_tests {
     #[test]
     fn factor_instance_in_accounts() {
         assert_eq!(
-            AccountOrPersona::a0().security_state.all_factor_instances(),
-            AccountOrPersona::a0().security_state.all_factor_instances()
+            Account::a0().security_state.all_factor_instances(),
+            Account::a0().security_state.all_factor_instances()
         );
         assert_eq!(
-            AccountOrPersona::a6().security_state.all_factor_instances(),
-            AccountOrPersona::a6().security_state.all_factor_instances()
+            Account::a6().security_state.all_factor_instances(),
+            Account::a6().security_state.all_factor_instances()
         );
     }
 }
@@ -507,7 +507,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a0()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -516,7 +517,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_intent_hash_is_signed() {
-        let tx = TransactionIntent::new([AccountOrPersona::a0()]);
+        let tx = TransactionIntent::new([Account::a0()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
         assert_eq!(signature.intent_hash(), &tx.intent_hash);
@@ -524,16 +525,16 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_has_signed() {
-        let account = AccountOrPersona::a0();
+        let account = Account::a0();
         let tx = TransactionIntent::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
-        assert_eq!(signature.owned_factor_instance().owner, account.address);
+        assert_eq!(signature.owned_factor_instance().owner, account.address());
     }
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_factor_instance_signed() {
-        let account = AccountOrPersona::a0();
+        let account = Account::a0();
         let tx = TransactionIntent::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
@@ -550,7 +551,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a1() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a1()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -559,7 +561,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a2() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a2()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -568,7 +571,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a3() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a3()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -577,7 +581,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a4() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a4()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -586,7 +591,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a5() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a5()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -595,7 +601,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a6() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a6()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -604,7 +611,8 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a7() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a7()])]);
+        let collector =
+            SignaturesCollector::test_prudent([TransactionIntent::new([Account::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -615,7 +623,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a0() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a0()]),
+            TransactionIntent::new([Account::a0()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -626,7 +634,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a1() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a1()]),
+            TransactionIntent::new([Account::a1()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -637,7 +645,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a2() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a2()]),
+            TransactionIntent::new([Account::a2()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -648,7 +656,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a3() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a3()]),
+            TransactionIntent::new([Account::a3()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -659,7 +667,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a4() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a4()]),
+            TransactionIntent::new([Account::a4()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -670,7 +678,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a5()]),
+            TransactionIntent::new([Account::a5()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -681,7 +689,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a6() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a6()]),
+            TransactionIntent::new([Account::a6()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -693,7 +701,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a7() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::a7()]),
+            TransactionIntent::new([Account::a7()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -704,7 +712,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5_last_factor_used() {
-        let entity = AccountOrPersona::a5();
+        let entity = Account::a5();
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
             TransactionIntent::new([entity.clone()]),
         ]);
@@ -732,7 +740,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([AccountOrPersona::securified_mainnet(0, "all override", |idx| {
+            TransactionIntent::new([Account::securified_mainnet(0, "all override", |idx| {
                 MatrixOfFactorInstances::override_only(
                     FactorSource::all()
                         .into_iter()
@@ -758,7 +766,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a0() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a0()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -769,7 +777,7 @@ mod signing_tests {
     async fn fail_get_skipped() {
         let failing = IndexSet::<_>::from_iter([FactorSourceID::fs0()]);
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([AccountOrPersona::a0()])],
+            [TransactionIntent::new([Account::a0()])],
             SimulatedFailures::with_simulated_failures(failing.clone()),
         );
         let outcome = collector.collect_signatures().await;
@@ -781,7 +789,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a1() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a1()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -791,7 +799,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a2() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a2()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -801,7 +809,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a3() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a3()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -811,7 +819,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a4() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a4()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -821,7 +829,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a5() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a5()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -831,7 +839,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a6() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a6()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -841,7 +849,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a7() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a7()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Account::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -851,7 +859,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn failure() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([AccountOrPersona::a0()])],
+            [TransactionIntent::new([Account::a0()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs0()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -861,7 +869,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([AccountOrPersona::a4()])],
+            [TransactionIntent::new([Account::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -879,7 +887,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([AccountOrPersona::a4()])],
+            [TransactionIntent::new([Account::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -53,7 +53,7 @@ mod key_derivation_tests {
             Arc::new(TestDerivationInteractors::fail()),
         );
         let outcome = collector.collect_keys().await;
-        println!("{:?}", outcome);
+        println!("{:#?}", outcome);
         assert!(outcome.all_factors().is_empty())
     }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -593,6 +593,7 @@ mod signing_tests {
                 )
             }
 
+            #[ignore]
             #[actix_rt::test]
             async fn prudent_user_single_tx_two_accounts_different_factor_sources() {
                 let collector = SignaturesCollector::test_prudent([TXToSign::new([

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -47,7 +47,7 @@ mod key_derivation_tests {
             .collect::<IndexSet<_>>();
         let collector = KeysCollector::new(
             FactorSource::all(),
-            [(factor_source.id, paths.clone())]
+            [(factor_source.factor_source_id(), paths.clone())]
                 .into_iter()
                 .collect::<IndexMap<FactorSourceID, IndexSet<DerivationPath>>>(),
             Arc::new(TestDerivationInteractors::fail()),
@@ -67,7 +67,8 @@ mod key_derivation_tests {
                 .into_iter()
                 .map(|i| DerivationPath::new(Mainnet, Account, T9n, i))
                 .collect::<IndexSet<_>>();
-            let collector = KeysCollector::new_test([(factor_source.id, paths.clone())]);
+            let collector =
+                KeysCollector::new_test([(factor_source.factor_source_id(), paths.clone())]);
             let outcome = collector.collect_keys().await;
             assert_eq!(
                 outcome
@@ -81,7 +82,7 @@ mod key_derivation_tests {
             assert!(outcome
                 .all_factors()
                 .into_iter()
-                .all(|f| f.factor_source_id == factor_source.id));
+                .all(|f| f.factor_source_id == factor_source.factor_source_id()));
         }
 
         #[actix_rt::test]
@@ -93,7 +94,7 @@ mod key_derivation_tests {
             let collector = KeysCollector::new_test(
                 factor_sources
                     .iter()
-                    .map(|f| (f.id, paths.clone()))
+                    .map(|f| (f.factor_source_id(), paths.clone()))
                     .collect_vec(),
             );
             let outcome = collector.collect_keys().await;
@@ -114,7 +115,7 @@ mod key_derivation_tests {
                     .collect::<HashSet::<_>>(),
                 factor_sources
                     .into_iter()
-                    .map(|f| f.id)
+                    .map(|f| f.factor_source_id())
                     .collect::<HashSet::<_>>()
             );
         }
@@ -131,7 +132,7 @@ mod key_derivation_tests {
             let collector = KeysCollector::new_test(
                 factor_sources
                     .iter()
-                    .map(|f| (f.id, paths.clone()))
+                    .map(|f| (f.factor_source_id(), paths.clone()))
                     .collect_vec(),
             );
             let outcome = collector.collect_keys().await;
@@ -153,7 +154,7 @@ mod key_derivation_tests {
                     .collect::<HashSet::<_>>(),
                 factor_sources
                     .into_iter()
-                    .map(|f| f.id)
+                    .map(|f| f.factor_source_id())
                     .collect::<HashSet::<_>>()
             );
         }
@@ -319,7 +320,7 @@ mod key_derivation_tests {
             let collector = KeysCollector::new_test(
                 factor_sources
                     .iter()
-                    .map(|f| (f.id, paths.clone()))
+                    .map(|f| (f.factor_source_id(), paths.clone()))
                     .collect_vec(),
             );
             let outcome = collector.collect_keys().await;
@@ -343,7 +344,7 @@ mod key_derivation_tests {
                     .collect::<HashSet::<_>>(),
                 factor_sources
                     .into_iter()
-                    .map(|f| f.id)
+                    .map(|f| f.factor_source_id())
                     .collect::<HashSet::<_>>()
             );
         }
@@ -375,7 +376,7 @@ mod key_derivation_tests {
                 factor.path(),
                 DerivationPath::new(network_id, entity_kind, key_kind, expected.index)
             );
-            assert_eq!(factor.factor_source_id, factor_source.id);
+            assert_eq!(factor.factor_source_id, factor_source.factor_source_id());
         }
 
         mod securified {
@@ -735,7 +736,7 @@ mod signing_tests {
                 MatrixOfFactorInstances::override_only(
                     FactorSource::all()
                         .into_iter()
-                        .map(|f| FactorInstance::account_mainnet_tx(idx, f.id)),
+                        .map(|f| FactorInstance::account_mainnet_tx(idx, f.factor_source_id())),
                 )
             })]),
         ]);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -508,6 +508,7 @@ mod signing_tests {
     mod multi_tx {
         use super::*;
 
+        #[ignore]
         #[actix_rt::test]
         async fn from_profile_accounts_and_personas() {
             let factor_sources = &FactorSource::all();
@@ -563,10 +564,30 @@ mod signing_tests {
 
     mod single_tx {
         use super::*;
+
+        mod multiple_entities {
+            use super::*;
+
+            #[actix_rt::test]
+            async fn prudent_user_single_tx_two_accounts_a0_a1() {
+                let collector = SignaturesCollector::test_prudent([TXToSign::new([
+                    Account::a0(),
+                    Account::a1(),
+                ])]);
+
+                let outcome = collector.collect_signatures().await;
+                assert!(outcome.successful());
+                let signatures = outcome.all_signatures();
+                assert_eq!(signatures.len(), 2);
+            }
+        }
+
         mod single_entity {
             use super::*;
+
             mod account {
                 use super::*;
+
                 #[actix_rt::test]
                 async fn prudent_user_single_tx_a0() {
                     let collector =
@@ -583,6 +604,10 @@ mod signing_tests {
                     let collector = SignaturesCollector::test_prudent([tx.clone()]);
                     let signature = &collector.collect_signatures().await.all_signatures()[0];
                     assert_eq!(signature.intent_hash(), &tx.intent_hash);
+                    assert_eq!(
+                        signature.derivation_path().entity_kind,
+                        CAP26EntityKind::Account
+                    );
                 }
 
                 #[actix_rt::test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -857,7 +857,7 @@ mod signing_tests {
                         TXToSign::new([Account::securified_mainnet(0, "all override", |idx| {
                             MatrixOfFactorInstances::override_only(
                                 FactorSource::all().into_iter().map(|f| {
-                                    HierarchicalDeterministicFactorInstance::account_mainnet_tx(
+                                    HierarchicalDeterministicFactorInstance::mainnet_tx_account(
                                         idx,
                                         f.factor_source_id(),
                                     )

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -512,13 +512,13 @@ mod signing_tests {
         #[actix_rt::test]
         async fn from_profile_accounts_and_personas() {
             let factor_sources = &FactorSource::all();
-            let a0 = &Account::a0(); // fs0
-            let a1 = &Account::a1(); // fs1
-            let a2 = &Account::a2(); // fs0
+            let a0 = &Account::a0();
+            let a1 = &Account::a1();
+            let a2 = &Account::a2();
 
-            let p0 = &Persona::p0(); // fs0, fs1, fs3, fs4, fs5
-            let p1 = &Persona::p1(); // 2, 6, 7, 8, 9
-            let p2 = &Persona::p2(); // 1, 4
+            let p0 = &Persona::p0();
+            let p1 = &Persona::p1();
+            let p2 = &Persona::p2();
 
             let t0 = TransactionIntent::address_of([a0, a1], [p0, p1]);
             let t1 = TransactionIntent::address_of([a0, a1, a2], []);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -20,12 +20,12 @@ mod common_tests {
     #[test]
     fn factor_instance_in_accounts() {
         assert_eq!(
-            Entity::a0().security_state.all_factor_instances(),
-            Entity::a0().security_state.all_factor_instances()
+            AccountOrPersona::a0().security_state.all_factor_instances(),
+            AccountOrPersona::a0().security_state.all_factor_instances()
         );
         assert_eq!(
-            Entity::a6().security_state.all_factor_instances(),
-            Entity::a6().security_state.all_factor_instances()
+            AccountOrPersona::a6().security_state.all_factor_instances(),
+            AccountOrPersona::a6().security_state.all_factor_instances()
         );
     }
 }
@@ -507,7 +507,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a0()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -516,7 +516,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_intent_hash_is_signed() {
-        let tx = TransactionIntent::new([Entity::a0()]);
+        let tx = TransactionIntent::new([AccountOrPersona::a0()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
         assert_eq!(signature.intent_hash(), &tx.intent_hash);
@@ -524,7 +524,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_has_signed() {
-        let account = Entity::a0();
+        let account = AccountOrPersona::a0();
         let tx = TransactionIntent::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
@@ -533,7 +533,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a0_assert_correct_owner_factor_instance_signed() {
-        let account = Entity::a0();
+        let account = AccountOrPersona::a0();
         let tx = TransactionIntent::new([account.clone()]);
         let collector = SignaturesCollector::test_prudent([tx.clone()]);
         let signature = &collector.collect_signatures().await.all_signatures()[0];
@@ -550,7 +550,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a1() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a1()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -559,7 +559,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a2() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a2()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -568,7 +568,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a3() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a3()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -577,7 +577,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a4() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a4()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -586,7 +586,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a5() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a5()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -595,7 +595,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a6() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a6()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -604,7 +604,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn prudent_user_single_tx_a7() {
-        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([Entity::a7()])]);
+        let collector = SignaturesCollector::test_prudent([TransactionIntent::new([AccountOrPersona::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
         let signatures = outcome.all_signatures();
@@ -615,7 +615,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a0() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a0()]),
+            TransactionIntent::new([AccountOrPersona::a0()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -626,7 +626,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a1() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a1()]),
+            TransactionIntent::new([AccountOrPersona::a1()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -637,7 +637,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_single_tx_a2() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a2()]),
+            TransactionIntent::new([AccountOrPersona::a2()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -648,7 +648,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a3() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a3()]),
+            TransactionIntent::new([AccountOrPersona::a3()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -659,7 +659,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a4() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a4()]),
+            TransactionIntent::new([AccountOrPersona::a4()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -670,7 +670,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a5()]),
+            TransactionIntent::new([AccountOrPersona::a5()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -681,7 +681,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a6() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a6()]),
+            TransactionIntent::new([AccountOrPersona::a6()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -693,7 +693,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a7() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::a7()]),
+            TransactionIntent::new([AccountOrPersona::a7()]),
         ]);
         let outcome = collector.collect_signatures().await;
         assert!(outcome.successful());
@@ -704,7 +704,7 @@ mod signing_tests {
 
     #[actix_rt::test]
     async fn lazy_sign_minimum_user_a5_last_factor_used() {
-        let entity = Entity::a5();
+        let entity = AccountOrPersona::a5();
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
             TransactionIntent::new([entity.clone()]),
         ]);
@@ -732,7 +732,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_sign_minimum_all_known_factors_used_as_override_factors_signed_with_device() {
         let collector = SignaturesCollector::test_lazy_sign_minimum_no_failures([
-            TransactionIntent::new([Entity::securified_mainnet(0, "all override", |idx| {
+            TransactionIntent::new([AccountOrPersona::securified_mainnet(0, "all override", |idx| {
                 MatrixOfFactorInstances::override_only(
                     FactorSource::all()
                         .into_iter()
@@ -758,7 +758,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a0() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a0()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a0()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -769,7 +769,7 @@ mod signing_tests {
     async fn fail_get_skipped() {
         let failing = IndexSet::<_>::from_iter([FactorSourceID::fs0()]);
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Entity::a0()])],
+            [TransactionIntent::new([AccountOrPersona::a0()])],
             SimulatedFailures::with_simulated_failures(failing.clone()),
         );
         let outcome = collector.collect_signatures().await;
@@ -781,7 +781,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a1() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a1()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a1()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -791,7 +791,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_single_tx_a2() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a2()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a2()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -801,7 +801,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a3() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a3()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a3()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -811,7 +811,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a4() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a4()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a4()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -821,7 +821,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a5() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a5()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a5()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -831,7 +831,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a6() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a6()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a6()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -841,7 +841,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn lazy_always_skip_user_a7() {
         let collector =
-            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([Entity::a7()])]);
+            SignaturesCollector::test_lazy_always_skip([TransactionIntent::new([AccountOrPersona::a7()])]);
         let outcome = collector.collect_signatures().await;
         assert!(!outcome.successful());
         let signatures = outcome.all_signatures();
@@ -851,7 +851,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn failure() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Entity::a0()])],
+            [TransactionIntent::new([AccountOrPersona::a0()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs0()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -861,7 +861,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_successful_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Entity::a4()])],
+            [TransactionIntent::new([AccountOrPersona::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;
@@ -879,7 +879,7 @@ mod signing_tests {
     #[actix_rt::test]
     async fn building_can_succeed_even_if_one_factor_source_fails_assert_ids_of_failed_tx() {
         let collector = SignaturesCollector::test_prudent_with_failures(
-            [TransactionIntent::new([Entity::a4()])],
+            [TransactionIntent::new([AccountOrPersona::a4()])],
             SimulatedFailures::with_simulated_failures([FactorSourceID::fs3()]),
         );
         let outcome = collector.collect_signatures().await;


### PR DESCRIPTION
I've found bug in signing module for multiple TX / multiple entities.

I've added two new failing tests, and ignored them.
```
#[ignore]
#[actix_rt::test]
async fn prudent_user_single_tx_two_accounts_different_factor_sources() {

#[ignore]
#[actix_rt::test]
 async fn from_profile_accounts_and_personas() {
```

All `signing` tests have been moved into separate modules inside of the `mod signing_tests` (under `single_key` `multi_tx` etc).

A new trait bridging over Persona and Account has been added and all single tx single entity tests with Account only has been generalized and reused for Personas too.

Otherwise this PR primarily harmonises method names of "Sargon emulated types" to make "integration" into Sargon easier.