### PR TITLE
Fix multi entity multi tx

### DIFF
--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -242,8 +242,23 @@ impl SignaturesCollector {
 }
 
 impl SignaturesCollector {
+    fn debug_print_expected_signatures(&self) {
+        let state = self.state.borrow();
+        let petitions = state.petitions.borrow();
+        println!("\n✨✨✨ Expected signatures - Per Transaction ✨✨✨\n");
+        for (txid, petition_tx) in petitions.txid_to_petition.borrow().iter() {
+            println!("\ttxid={:?}", txid);
+            for (entity_address, petition_entity) in petition_tx.for_entities.borrow().iter() {
+                println!("\t\tentity={:?}", entity_address);
+                for factor in petition_entity.all_factor_instances() {
+                    println!("\t\t\tfactor={:#?}", factor);
+                }
+            }
+        }
+    }
+
     pub async fn collect_signatures(self) -> SignaturesOutcome {
-        for (k0, v0) in self.state.borrow().petitions.
+        self.debug_print_expected_signatures();
         _ = self
             .sign_with_factors() // in decreasing "friction order"
             .await

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -242,23 +242,7 @@ impl SignaturesCollector {
 }
 
 impl SignaturesCollector {
-    fn debug_print_expected_signatures(&self) {
-        let state = self.state.borrow();
-        let petitions = state.petitions.borrow();
-        println!("\n✨✨✨ Expected signatures - Per Transaction ✨✨✨\n");
-        for (txid, petition_tx) in petitions.txid_to_petition.borrow().iter() {
-            println!("\ttxid={:?}", txid);
-            for (entity_address, petition_entity) in petition_tx.for_entities.borrow().iter() {
-                println!("\t\tentity={:?}", entity_address);
-                for factor in petition_entity.all_factor_instances() {
-                    println!("\t\t\tfactor={:#?}", factor);
-                }
-            }
-        }
-    }
-
     pub async fn collect_signatures(self) -> SignaturesOutcome {
-        self.debug_print_expected_signatures();
         _ = self
             .sign_with_factors() // in decreasing "friction order"
             .await

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -157,8 +157,6 @@ impl SignaturesCollector {
     async fn sign_with_factors(&self) -> Result<()> {
         let factors_of_kind = self.dependencies.factors_of_kind.clone();
         for factor_sources_of_kind in factors_of_kind.into_iter() {
-            println!("🔮 state: {:#?}", &self.state.borrow());
-
             if !self.continue_if_necessary()? {
                 break; // finished early, we have fulfilled signing requirements of all transactions
             }
@@ -245,6 +243,7 @@ impl SignaturesCollector {
 
 impl SignaturesCollector {
     pub async fn collect_signatures(self) -> SignaturesOutcome {
+        for (k0, v0) in self.state.borrow().petitions.
         _ = self
             .sign_with_factors() // in decreasing "friction order"
             .await

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -137,10 +137,13 @@ impl SignaturesCollector {
         factor_sources_of_kind: FactorSourcesOfKind,
     ) -> Result<()> {
         let interactor = self.get_interactor(factor_sources_of_kind.kind);
+
         let client = SignWithFactorClient::new(interactor);
+
         let result = client
             .use_factor_sources(factor_sources_of_kind.factor_sources(), self)
             .await;
+
         match result {
             Ok(_) => {}
             Err(_) => self.process_batch_response(SignWithFactorSourceOrSourcesOutcome::Skipped {
@@ -156,12 +159,11 @@ impl SignaturesCollector {
         for factor_sources_of_kind in factors_of_kind.into_iter() {
             println!("🔮 state: {:#?}", &self.state.borrow());
 
-            self.sign_with_factors_of_kind(factor_sources_of_kind)
-                .await?;
-
             if !self.continue_if_necessary()? {
                 break; // finished early, we have fulfilled signing requirements of all transactions
             }
+            self.sign_with_factors_of_kind(factor_sources_of_kind)
+                .await?;
         }
         Ok(())
     }

--- a/src/signing/interactors/parallel_batch_signing_request.rs
+++ b/src/signing/interactors/parallel_batch_signing_request.rs
@@ -2,6 +2,8 @@ use crate::prelude::*;
 
 /// A collection of factor sources to use to sign, transactions with multiple keys
 /// (derivations paths).
+#[derive(derive_more::Debug)]
+#[debug("per_factor_source: {:#?}", per_factor_source)]
 pub struct ParallelBatchSigningRequest {
     /// Per factor source, a set of transactions to sign, with
     /// multiple derivations paths.
@@ -11,6 +13,7 @@ pub struct ParallelBatchSigningRequest {
     /// signing with this factor source.
     pub invalid_transactions_if_skipped: IndexSet<InvalidTransactionIfSkipped>,
 }
+
 impl ParallelBatchSigningRequest {
     pub fn new(
         per_factor_source: IndexMap<FactorSourceID, BatchTXBatchKeySigningRequest>,

--- a/src/signing/interactors/serial_batch_signing_request.rs
+++ b/src/signing/interactors/serial_batch_signing_request.rs
@@ -4,6 +4,8 @@ use crate::prelude::*;
 /// a collection of transactions to sign with multiple keys (derivation paths),
 /// and a collection of transactions which would be invalid if the user skips
 /// signing with this factor source.
+#[derive(derive_more::Debug)]
+#[debug("input: {:#?}", input)]
 pub struct SerialBatchSigningRequest {
     pub input: BatchTXBatchKeySigningRequest,
     /// A collection of transactions which would be invalid if the user skips

--- a/src/signing/interactors/sign_with_factor_client.rs
+++ b/src/signing/interactors/sign_with_factor_client.rs
@@ -24,9 +24,7 @@ impl SignWithFactorClient {
                         .map(|f| f.factor_source_id())
                         .collect(),
                 );
-                println!("🌈 request: {:#?}", &request);
                 let response = interactor.sign(request).await?;
-                println!("🌈 response: {:#?}", &response);
                 collector.process_batch_response(response);
             }
 
@@ -39,12 +37,9 @@ impl SignWithFactorClient {
                     // Prepare the request for the interactor
                     let request =
                         collector.request_for_serial_interactor(&factor_source.factor_source_id());
-                    println!("🌈 request: {:#?}", &request);
 
                     // Produce the results from the interactor
                     let response = interactor.sign(request).await?;
-
-                    println!("🌈 response: {:#?}", &response);
 
                     // Report the results back to the collector
                     collector.process_batch_response(response);

--- a/src/signing/interactors/sign_with_factor_client.rs
+++ b/src/signing/interactors/sign_with_factor_client.rs
@@ -37,9 +37,12 @@ impl SignWithFactorClient {
                     // Prepare the request for the interactor
                     let request =
                         collector.request_for_serial_interactor(&factor_source.factor_source_id());
+                    println!("🌈 request: {:#?}", &request);
 
                     // Produce the results from the interactor
                     let response = interactor.sign(request).await?;
+
+                    println!("🌈 response: {:#?}", &response);
 
                     // Report the results back to the collector
                     collector.process_batch_response(response);

--- a/src/signing/interactors/sign_with_factor_client.rs
+++ b/src/signing/interactors/sign_with_factor_client.rs
@@ -24,7 +24,9 @@ impl SignWithFactorClient {
                         .map(|f| f.factor_source_id())
                         .collect(),
                 );
+                println!("🌈 request: {:#?}", &request);
                 let response = interactor.sign(request).await?;
+                println!("🌈 response: {:#?}", &response);
                 collector.process_batch_response(response);
             }
 

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -20,26 +20,6 @@ pub struct PetitionEntity {
 }
 
 impl PetitionEntity {
-    #[allow(unused)]
-    fn debug_str(&self) -> String {
-        let thres: String = self
-            .threshold_factors
-            .clone()
-            .map(|f| format!("threshold_factors {:#?}", f.borrow()))
-            .unwrap_or_default();
-
-        let overr: String = self
-            .override_factors
-            .clone()
-            .map(|f| format!("override_factors {:#?}", f.borrow()))
-            .unwrap_or_default();
-
-        format!(
-            "intent_hash: {:#?}, entity: {:#?}, {:#?}{:#?}",
-            self.intent_hash, self.entity, thres, overr
-        )
-    }
-
     pub fn new(
         intent_hash: IntentHash,
         entity: AddressOfAccountOrPersona,
@@ -255,6 +235,26 @@ impl PetitionEntity {
             },
         }
     }
+
+    #[allow(unused)]
+    fn debug_str(&self) -> String {
+        let thres: String = self
+            .threshold_factors
+            .clone()
+            .map(|f| format!("threshold_factors {:#?}", f.borrow()))
+            .unwrap_or_default();
+
+        let overr: String = self
+            .override_factors
+            .clone()
+            .map(|f| format!("override_factors {:#?}", f.borrow()))
+            .unwrap_or_default();
+
+        format!(
+            "intent_hash: {:#?}, entity: {:#?}, {:#?}{:#?}",
+            self.intent_hash, self.entity, thres, overr
+        )
+    }
 }
 
 impl PetitionEntity {
@@ -382,5 +382,11 @@ mod tests {
     #[test]
     fn inequality() {
         assert_ne!(Sut::sample(), Sut::sample_other())
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(Sut::sample(), Sut::sample());
+        assert_eq!(Sut::sample_other(), Sut::sample_other());
     }
 }

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -287,6 +287,11 @@ mod tests {
     type Sut = PetitionEntity;
 
     #[test]
+    fn debug() {
+        pretty_assertions::assert_eq!(format!("{:?}", Sut::sample()), "intent_hash: TXID(\"dedede\"), entity: acco_Grace, \"threshold_factors PetitionFactors(input: PetitionFactorsInput(factors: {\\n    factor_source_id: Device:00000000-0000-0000-0000-000000000000, derivation_path: 0/A/tx/6,\\n    factor_source_id: Arculus:00000000-0000-0000-0000-000000000003, derivation_path: 0/A/tx/6,\\n    factor_source_id: Yubikey:00000000-0000-0000-0000-000000000005, derivation_path: 0/A/tx/6,\\n}), state_snapshot: signatures: \\\"\\\", skipped: \\\"\\\")\"\"override_factors PetitionFactors(input: PetitionFactorsInput(factors: {\\n    factor_source_id: Ledger:00000000-0000-0000-0000-000000000001, derivation_path: 0/A/tx/6,\\n    factor_source_id: Arculus:00000000-0000-0000-0000-000000000004, derivation_path: 0/A/tx/6,\\n}), state_snapshot: signatures: \\\"\\\", skipped: \\\"\\\")\"");
+    }
+
+    #[test]
     #[should_panic(expected = "Programmer error! Must have at least one factors list.")]
     fn invalid_empty_factors() {
         Sut::new(

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -12,14 +12,20 @@ pub struct PetitionFactors {
     state: RefCell<PetitionFactorsState>,
 }
 
-impl PetitionFactors {
-    pub fn debug_str(&self) -> String {
-        format!(
-            "PetitionFactors(input: {:#?}, state_snapshot: {:#?})",
-            self.input,
-            self.state_snapshot()
+impl HasSampleValues for PetitionFactors {
+    fn sample() -> Self {
+        Self::new(FactorListKind::Threshold, PetitionFactorsInput::sample())
+    }
+
+    fn sample_other() -> Self {
+        Self::new(
+            FactorListKind::Override,
+            PetitionFactorsInput::sample_other(),
         )
     }
+}
+
+impl PetitionFactors {
     pub fn new(factor_list_kind: FactorListKind, input: PetitionFactorsInput) -> Self {
         Self {
             factor_list_kind,
@@ -158,5 +164,13 @@ impl PetitionFactors {
             return PetitionFactorsStatus::Finished(finished_state);
         }
         PetitionFactorsStatus::InProgress
+    }
+
+    pub fn debug_str(&self) -> String {
+        format!(
+            "PetitionFactors(input: {:#?}, state_snapshot: {:#?})",
+            self.input,
+            self.state_snapshot()
+        )
     }
 }

--- a/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_input.rs
@@ -11,6 +11,25 @@ pub struct PetitionFactorsInput {
     pub(super) required: i8,
 }
 
+impl HasSampleValues for PetitionFactorsInput {
+    fn sample() -> Self {
+        Self::new(
+            IndexSet::from_iter([
+                HierarchicalDeterministicFactorInstance::sample(),
+                HierarchicalDeterministicFactorInstance::sample_other(),
+            ]),
+            1,
+        )
+    }
+
+    fn sample_other() -> Self {
+        Self::new(
+            IndexSet::from_iter([HierarchicalDeterministicFactorInstance::sample_other()]),
+            1,
+        )
+    }
+}
+
 impl PetitionFactorsInput {
     pub(super) fn new(
         factors: IndexSet<HierarchicalDeterministicFactorInstance>,

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -14,19 +14,21 @@ pub(super) struct PetitionFactorsStateSnapshot {
 impl PetitionFactorsStateSnapshot {
     #[allow(unused)]
     fn debug_str(&self) -> String {
-        format!(
-            "signatures: {:#?}, skipped: {:#?}",
-            self.signed
-                .clone()
-                .into_iter()
-                .map(|s| format!("{:#?}", s))
-                .join(", "),
-            self.skipped
-                .clone()
-                .into_iter()
-                .map(|s| format!("{:#?}", s))
-                .join(", ")
-        )
+        let signatures = self
+            .signed
+            .clone()
+            .into_iter()
+            .map(|s| format!("{:#?}", s))
+            .join(", ");
+
+        let skipped = self
+            .skipped
+            .clone()
+            .into_iter()
+            .map(|s| format!("{:#?}", s))
+            .join(", ");
+
+        format!("signatures: {:#?}, skipped: {:#?}", signatures, skipped)
     }
 
     pub(super) fn new(

--- a/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors_state_snapshot.rs
@@ -12,6 +12,25 @@ pub(super) struct PetitionFactorsStateSnapshot {
 }
 
 impl PetitionFactorsStateSnapshot {
+    pub(super) fn new(
+        signed: IndexSet<HDSignature>,
+        skipped: IndexSet<HierarchicalDeterministicFactorInstance>,
+    ) -> Self {
+        Self { signed, skipped }
+    }
+
+    pub(super) fn prompted_count(&self) -> i8 {
+        self.signed_count() + self.skipped_count()
+    }
+
+    pub(super) fn signed_count(&self) -> i8 {
+        self.signed.len() as i8
+    }
+
+    fn skipped_count(&self) -> i8 {
+        self.skipped.len() as i8
+    }
+
     #[allow(unused)]
     fn debug_str(&self) -> String {
         let signatures = self
@@ -30,22 +49,45 @@ impl PetitionFactorsStateSnapshot {
 
         format!("signatures: {:#?}, skipped: {:#?}", signatures, skipped)
     }
+}
 
-    pub(super) fn new(
-        signed: IndexSet<HDSignature>,
-        skipped: IndexSet<HierarchicalDeterministicFactorInstance>,
-    ) -> Self {
-        Self { signed, skipped }
+impl HasSampleValues for PetitionFactorsStateSnapshot {
+    fn sample() -> Self {
+        Self::new(
+            IndexSet::from_iter([HDSignature::sample(), HDSignature::sample_other()]),
+            IndexSet::from_iter([
+                HierarchicalDeterministicFactorInstance::sample(),
+                HierarchicalDeterministicFactorInstance::sample_other(),
+            ]),
+        )
     }
-    pub(super) fn prompted_count(&self) -> i8 {
-        self.signed_count() + self.skipped_count()
+    fn sample_other() -> Self {
+        Self::new(
+            IndexSet::from_iter([HDSignature::sample_other()]),
+            IndexSet::from_iter([HierarchicalDeterministicFactorInstance::sample_other()]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Sut = PetitionFactorsStateSnapshot;
+
+    #[test]
+    fn equality() {
+        assert_eq!(Sut::sample(), Sut::sample());
+        assert_eq!(Sut::sample_other(), Sut::sample_other());
     }
 
-    pub(super) fn signed_count(&self) -> i8 {
-        self.signed.len() as i8
+    #[test]
+    fn inequality() {
+        assert_ne!(Sut::sample(), Sut::sample_other())
     }
 
-    fn skipped_count(&self) -> i8 {
-        self.skipped.len() as i8
+    #[test]
+    fn debug() {
+        assert_eq!(format!("{:?}", Sut::sample()), "signatures: \"HDSignature { input: HDSignatureInput { intent_hash: TXID(\\\"dedede\\\"), owned_factor_instance: acco_Alice: factor_source_id: Device:dededede-dede-dede-dede-dededededede, derivation_path: 0/A/tx/0 } }, HDSignature { input: HDSignatureInput { intent_hash: TXID(\\\"ababab\\\"), owned_factor_instance: ident_Alice: factor_source_id: Ledger:1e1e1e1e-1e1e-1e1e-1e1e-1e1e1e1e1e1e, derivation_path: 0/A/tx/1 } }\", skipped: \"factor_source_id: Device:dededede-dede-dede-dede-dededededede, derivation_path: 0/A/tx/0, factor_source_id: Ledger:1e1e1e1e-1e1e-1e1e-1e1e-1e1e1e1e1e1e, derivation_path: 0/A/tx/1\"");
     }
 }

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -32,6 +32,7 @@ impl Petitions {
             .map(|p| format!("Petitions({:#?}: {:#?})", p.0, p.1))
             .join(" + ")
     }
+
     pub fn outcome(self) -> SignaturesOutcome {
         let txid_to_petition = self.txid_to_petition.into_inner();
         let mut failed_transactions = MaybeSignedTransactions::empty();
@@ -80,7 +81,9 @@ impl Petitions {
             })
             .collect::<Result<Vec<bool>>>()?;
 
-        let should_continue_signal = should_continue_signals.into_iter().all(|b| b);
+        // If **any** petition says we should continue, we must continue.
+        let should_continue_signal = should_continue_signals.into_iter().any(|b| b);
+
         Ok(should_continue_signal)
     }
 

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-#[derive(derive_more::Debug)]
+#[derive(derive_more::Debug, PartialEq, Eq)]
 #[debug("{}", self.debug_str())]
 pub(crate) struct Petitions {
     /// Lookup from factor to TXID.
@@ -24,13 +24,14 @@ pub(crate) struct Petitions {
 }
 
 impl Petitions {
-    #[allow(unused)]
-    fn debug_str(&self) -> String {
-        self.txid_to_petition
-            .borrow()
-            .iter()
-            .map(|p| format!("Petitions({:#?}: {:#?})", p.0, p.1))
-            .join(" + ")
+    pub(crate) fn new(
+        factor_to_txid: HashMap<FactorSourceID, IndexSet<IntentHash>>,
+        txid_to_petition: IndexMap<IntentHash, PetitionTransaction>,
+    ) -> Self {
+        Self {
+            factor_to_txid,
+            txid_to_petition: RefCell::new(txid_to_petition),
+        }
     }
 
     pub fn outcome(self) -> SignaturesOutcome {
@@ -53,16 +54,6 @@ impl Petitions {
             failed_transactions,
             skipped_factor_sources,
         )
-    }
-
-    pub(crate) fn new(
-        factor_to_txid: HashMap<FactorSourceID, IndexSet<IntentHash>>,
-        txid_to_petition: IndexMap<IntentHash, PetitionTransaction>,
-    ) -> Self {
-        Self {
-            factor_to_txid,
-            txid_to_petition: RefCell::new(txid_to_petition),
-        }
     }
 
     /// `Ok(true)` means "continue", `Ok(false)` means "stop, we are done". `Err(_)` means "stop, we have failed".
@@ -156,5 +147,61 @@ impl Petitions {
                 }
             }
         }
+    }
+
+    #[allow(unused)]
+    fn debug_str(&self) -> String {
+        self.txid_to_petition
+            .borrow()
+            .iter()
+            .map(|p| format!("Petitions({:#?}: {:#?})", p.0, p.1))
+            .join(" + ")
+    }
+}
+
+impl HasSampleValues for Petitions {
+    fn sample() -> Self {
+        let p0 = PetitionTransaction::sample();
+        Self::new(
+            HashMap::from_iter([(
+                FactorSourceID::fs0(),
+                IndexSet::from_iter([p0.intent_hash.clone()]),
+            )]),
+            IndexMap::from_iter([(p0.intent_hash.clone(), p0)]),
+        )
+    }
+
+    fn sample_other() -> Self {
+        let p1 = PetitionTransaction::sample();
+        Self::new(
+            HashMap::from_iter([(
+                FactorSourceID::fs1(),
+                IndexSet::from_iter([p1.intent_hash.clone()]),
+            )]),
+            IndexMap::from_iter([(p1.intent_hash.clone(), p1)]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Sut = Petitions;
+
+    #[test]
+    fn equality_of_samples() {
+        assert_eq!(Sut::sample(), Sut::sample());
+        assert_eq!(Sut::sample_other(), Sut::sample_other());
+    }
+
+    #[test]
+    fn inequality_of_samples() {
+        assert_ne!(Sut::sample(), Sut::sample_other());
+    }
+
+    #[test]
+    fn debug() {
+        assert_eq!(format!("{:?}", Sut::sample()), "Petitions(TXID(\"dedede\"): PetitionTransaction(for_entities: [PetitionEntity(intent_hash: TXID(\"dedede\"), entity: acco_Grace, \"threshold_factors PetitionFactors(input: PetitionFactorsInput(factors: {\\n    factor_source_id: Device:dededede-dede-dede-dede-dededededede, derivation_path: 0/A/tx/0,\\n    factor_source_id: Ledger:1e1e1e1e-1e1e-1e1e-1e1e-1e1e1e1e1e1e, derivation_path: 0/A/tx/1,\\n}), state_snapshot: signatures: \\\"\\\", skipped: \\\"\\\")\"\"override_factors PetitionFactors(input: PetitionFactorsInput(factors: {\\n    factor_source_id: Ledger:1e1e1e1e-1e1e-1e1e-1e1e-1e1e1e1e1e1e, derivation_path: 0/A/tx/1,\\n}), state_snapshot: signatures: \\\"\\\", skipped: \\\"\\\")\")]))");
     }
 }

--- a/src/signing/signatures_outcome_types/signatures_outcome.rs
+++ b/src/signing/signatures_outcome_types/signatures_outcome.rs
@@ -70,6 +70,10 @@ impl SignaturesOutcome {
         self.successful_transactions.clone().transactions()
     }
 
+    pub fn failed_transactions(&self) -> Vec<SignedTransaction> {
+        self.failed_transactions.clone().transactions()
+    }
+
     pub fn skipped_factor_sources(&self) -> IndexSet<FactorSourceID> {
         self.skipped_factor_sources.clone()
     }

--- a/src/signing/signatures_outcome_types/signatures_outcome.rs
+++ b/src/signing/signatures_outcome_types/signatures_outcome.rs
@@ -66,6 +66,12 @@ impl SignaturesOutcome {
         self.successful_transactions.all_signatures()
     }
 
+
+    pub fn successful_transactions(&self) -> IndexSet<HDSignature> {
+        self.successful_transactions
+    }
+
+
     pub fn skipped_factor_sources(&self) -> IndexSet<FactorSourceID> {
         self.skipped_factor_sources.clone()
     }

--- a/src/signing/signatures_outcome_types/signatures_outcome.rs
+++ b/src/signing/signatures_outcome_types/signatures_outcome.rs
@@ -66,11 +66,9 @@ impl SignaturesOutcome {
         self.successful_transactions.all_signatures()
     }
 
-
-    pub fn successful_transactions(&self) -> IndexSet<HDSignature> {
-        self.successful_transactions
+    pub fn successful_transactions(&self) -> Vec<SignedTransaction> {
+        self.successful_transactions.clone().transactions()
     }
-
 
     pub fn skipped_factor_sources(&self) -> IndexSet<FactorSourceID> {
         self.skipped_factor_sources.clone()

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -58,6 +58,14 @@ impl FactorSource {
 
 use once_cell::sync::Lazy;
 
+pub static ID_STEPPER: Lazy<UuidStepper> = Lazy::new(UuidStepper::new);
+
+impl UuidStepper {
+    pub fn next() -> Uuid {
+        ID_STEPPER._next()
+    }
+}
+
 pub static ALL_FACTOR_SOURCES: Lazy<[FactorSource; 10]> = Lazy::new(|| {
     [
         FactorSource::fs0(),

--- a/src/testing/signing/test_interactors/test_serial_interactor.rs
+++ b/src/testing/signing/test_interactors/test_serial_interactor.rs
@@ -32,7 +32,6 @@ impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
             .sign_or_skip(invalid_transactions_if_skipped)
         {
             SigningUserInput::Sign => {
-                println!("\n#####################\n");
                 let signatures = request
                     .input
                     .per_transaction
@@ -40,31 +39,10 @@ impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
                     .flat_map(|r| {
                         r.signature_inputs()
                             .iter()
-                            .map(|x| {
-                                let sig = HDSignature::produced_signing_with_input(x.clone());
-                                println!("\n✅ ✅ SIGNATURE ✅ ✅");
-                                println!(
-                                    "factor={:?}",
-                                    &sig.input
-                                        .owned_factor_instance
-                                        .factor_instance()
-                                        .factor_source_id
-                                );
-                                println!("tx={:?}", &sig.input.intent_hash);
-                                println!("owner={:?}", &sig.input.owned_factor_instance.owner);
-                                println!(
-                                    "path={:?}",
-                                    &sig.input
-                                        .owned_factor_instance
-                                        .factor_instance()
-                                        .derivation_path()
-                                );
-                                sig
-                            })
+                            .map(|x| HDSignature::produced_signing_with_input(x.clone()))
                             .collect::<IndexSet<_>>()
                     })
                     .collect::<IndexSet<HDSignature>>();
-                println!("\nSIGNATURES END\n\n#####################\n");
                 let signatures = signatures
                     .into_iter()
                     .into_group_map_by(|x| x.factor_source_id());

--- a/src/testing/signing/test_interactors/test_serial_interactor.rs
+++ b/src/testing/signing/test_interactors/test_serial_interactor.rs
@@ -42,7 +42,7 @@ impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
                             .iter()
                             .map(|x| {
                                 let sig = HDSignature::produced_signing_with_input(x.clone());
-                                println!("\n✍🏻 ✍🏻 SIGNATURE ✍🏻 ✍🏻");
+                                println!("\n✅ ✅ SIGNATURE ✅ ✅");
                                 println!(
                                     "factor={:?}",
                                     &sig.input

--- a/src/testing/signing/test_interactors/test_serial_interactor.rs
+++ b/src/testing/signing/test_interactors/test_serial_interactor.rs
@@ -32,6 +32,7 @@ impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
             .sign_or_skip(invalid_transactions_if_skipped)
         {
             SigningUserInput::Sign => {
+                println!("\n#####################\n");
                 let signatures = request
                     .input
                     .per_transaction
@@ -39,10 +40,31 @@ impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
                     .flat_map(|r| {
                         r.signature_inputs()
                             .iter()
-                            .map(|x| HDSignature::produced_signing_with_input(x.clone()))
+                            .map(|x| {
+                                let sig = HDSignature::produced_signing_with_input(x.clone());
+                                println!("\n✍🏻 ✍🏻 SIGNATURE ✍🏻 ✍🏻");
+                                println!(
+                                    "factor={:?}",
+                                    &sig.input
+                                        .owned_factor_instance
+                                        .factor_instance()
+                                        .factor_source_id
+                                );
+                                println!("tx={:?}", &sig.input.intent_hash);
+                                println!("owner={:?}", &sig.input.owned_factor_instance.owner);
+                                println!(
+                                    "path={:?}",
+                                    &sig.input
+                                        .owned_factor_instance
+                                        .factor_instance()
+                                        .derivation_path()
+                                );
+                                sig
+                            })
                             .collect::<IndexSet<_>>()
                     })
                     .collect::<IndexSet<HDSignature>>();
+                println!("\nSIGNATURES END\n\n#####################\n");
                 let signatures = signatures
                     .into_iter()
                     .into_group_map_by(|x| x.factor_source_id());

--- a/src/types/sargon_types.rs
+++ b/src/types/sargon_types.rs
@@ -2,8 +2,9 @@ use std::marker::PhantomData;
 
 use crate::prelude::*;
 
-#[derive(Clone, Copy, PartialEq, Eq, std::hash::Hash, derive_more::Debug)]
-#[debug("{kind}:{id}")]
+#[derive(Clone, Copy, PartialEq, Eq, std::hash::Hash, derive_more::Display, derive_more::Debug)]
+#[display("{kind}:{id}")]
+#[debug("{}", self.to_string())]
 pub struct FactorSourceID {
     pub kind: FactorSourceKind,
     pub id: Uuid,
@@ -132,9 +133,14 @@ impl HasSampleValues for FactorSourceKind {
 pub type DerivationIndex = u32;
 
 #[repr(u8)]
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::Debug)]
 pub enum CAP26KeyKind {
+    #[display("tx")]
+    #[debug("tx")]
     T9n,
+
+    #[display("rola")]
+    #[debug("rola")]
     Rola,
 }
 impl CAP26KeyKind {
@@ -144,11 +150,17 @@ impl CAP26KeyKind {
 }
 
 #[repr(u8)]
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::Debug)]
 pub enum NetworkID {
+    #[display("Mainnet")]
+    #[debug("0")]
     Mainnet,
+
+    #[display("Stokenet")]
+    #[debug("1")]
     Stokenet,
 }
+
 impl NetworkID {
     fn discriminant(&self) -> u8 {
         core::intrinsics::discriminant_value(self)
@@ -156,9 +168,14 @@ impl NetworkID {
 }
 
 #[repr(u8)]
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, derive_more::Display, derive_more::Debug)]
 pub enum CAP26EntityKind {
+    #[display("Account")]
+    #[debug("A")]
     Account,
+
+    #[display("Identity")]
+    #[debug("I")]
     Identity,
 }
 
@@ -168,7 +185,9 @@ impl CAP26EntityKind {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, derive_more::Display, derive_more::Debug)]
+#[display("{}/{}/{}/{}", network_id, entity_kind, key_kind, index)]
+#[debug("{:?}/{:?}/{:?}/{:?}", network_id, entity_kind, key_kind, index)]
 pub struct DerivationPath {
     pub network_id: NetworkID,
     pub entity_kind: CAP26EntityKind,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -526,27 +526,6 @@ mod signing_tests {
 
             let profile = Profile::new(factor_sources.clone(), [a0, a1, a2], [p0, p1, p2]);
 
-            type F = FactorSourceID;
-            assert!([
-                F::fs0(),
-                F::fs1(),
-                F::fs2(),
-                F::fs3(),
-                F::fs4(),
-                F::fs5(),
-                F::fs6(),
-                F::fs7(),
-                F::fs8(),
-                F::fs9()
-            ]
-            .iter()
-            .all(|f| {
-                factor_sources
-                    .iter()
-                    .map(|x| x.factor_source_id())
-                    .contains(f)
-            }));
-
             let collector = SignaturesCollector::new(
                 IndexSet::<TransactionIntent>::from_iter([t0, t1, t2]),
                 Arc::new(TestSignatureCollectingInteractors::new(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -509,7 +509,7 @@ mod signing_tests {
         use super::*;
 
         #[actix_rt::test]
-        async fn from_profile_accounts_and_personas() {
+        async fn multi_accounts_multi_personas_all_single_factor_controlled() {
             let factor_sources = &FactorSource::all();
             let a0 = &Account::a0();
             let a1 = &Account::a1();
@@ -548,6 +548,50 @@ mod signing_tests {
                     t1.clone().intent_hash,
                     t2.clone().intent_hash,
                 ])
+            );
+            let st0 = outcome
+                .successful_transactions()
+                .into_iter()
+                .find(|st| st.intent_hash == t0.intent_hash)
+                .unwrap();
+
+            assert_eq!(
+                st0.signatures
+                    .clone()
+                    .into_iter()
+                    .map(|s| s.owned_factor_instance().owner.clone())
+                    .collect::<HashSet<_>>(),
+                HashSet::from_iter([a0.address(), a1.address(), p0.address(), p1.address()])
+            );
+
+            let st1 = outcome
+                .successful_transactions()
+                .into_iter()
+                .find(|st| st.intent_hash == t1.intent_hash)
+                .unwrap();
+
+            assert_eq!(
+                st1.signatures
+                    .clone()
+                    .into_iter()
+                    .map(|s| s.owned_factor_instance().owner.clone())
+                    .collect::<HashSet<_>>(),
+                HashSet::from_iter([a0.address(), a1.address(), a2.address()])
+            );
+
+            let st2 = outcome
+                .successful_transactions()
+                .into_iter()
+                .find(|st| st.intent_hash == t2.intent_hash)
+                .unwrap();
+
+            assert_eq!(
+                st2.signatures
+                    .clone()
+                    .into_iter()
+                    .map(|s| s.owned_factor_instance().owner.clone())
+                    .collect::<HashSet<_>>(),
+                HashSet::from_iter([p0.address(), p1.address(), p2.address()])
             );
         }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -535,7 +535,8 @@ mod signing_tests {
             .unwrap();
 
             let outcome = collector.collect_signatures().await;
-            assert!(outcome.signatures_of_failed_transactions().is_empty());
+            assert!(outcome.successful());
+            assert!(outcome.failed_transactions().is_empty());
             assert_eq!(outcome.signatures_of_successful_transactions().len(), 10);
             assert_eq!(
                 outcome

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -571,7 +571,6 @@ mod signing_tests {
                 )
             }
 
-            #[ignore]
             #[actix_rt::test]
             async fn prudent_user_single_tx_two_accounts_different_factor_sources() {
                 let collector = SignaturesCollector::test_prudent([TXToSign::new([

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -508,7 +508,6 @@ mod signing_tests {
     mod multi_tx {
         use super::*;
 
-        #[ignore]
         #[actix_rt::test]
         async fn from_profile_accounts_and_personas() {
             let factor_sources = &FactorSource::all();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -536,8 +536,12 @@ mod signing_tests {
 
             let outcome = collector.collect_signatures().await;
             assert!(outcome.signatures_of_failed_transactions().is_empty());
-            assert!(outcome.signatures_of_successful_transactions().len() > 2);
+            assert_eq!(outcome.signatures_of_successful_transactions().len(), 10);
+            assert_eq!(outcome.suc);
         }
+
+        #[actix_rt::test]
+        async fn multi_securified_entities() {}
     }
 
     mod single_tx {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -526,7 +526,7 @@ mod signing_tests {
             let profile = Profile::new(factor_sources.clone(), [a0, a1, a2], [p0, p1, p2]);
 
             let collector = SignaturesCollector::new(
-                IndexSet::<TransactionIntent>::from_iter([t0, t1, t2]),
+                IndexSet::<TransactionIntent>::from_iter([t0.clone(), t1.clone(), t2.clone()]),
                 Arc::new(TestSignatureCollectingInteractors::new(
                     SimulatedUser::prudent_no_fail(),
                 )),
@@ -537,7 +537,18 @@ mod signing_tests {
             let outcome = collector.collect_signatures().await;
             assert!(outcome.signatures_of_failed_transactions().is_empty());
             assert_eq!(outcome.signatures_of_successful_transactions().len(), 10);
-            assert_eq!(outcome.suc);
+            assert_eq!(
+                outcome
+                    .successful_transactions()
+                    .into_iter()
+                    .map(|t| t.intent_hash)
+                    .collect::<HashSet<_>>(),
+                HashSet::from_iter([
+                    t0.clone().intent_hash,
+                    t1.clone().intent_hash,
+                    t2.clone().intent_hash,
+                ])
+            );
         }
 
         #[actix_rt::test]


### PR DESCRIPTION
Added and then removed, useful debugging:

### `SignaturesCollector`
```rust
impl SignaturesCollector {
    fn debug_print_expected_signatures(&self) {
        let state = self.state.borrow();
        let petitions = state.petitions.borrow();
        println!("\n✨✨✨ Expected signatures - Per Transaction ✨✨✨\n");
        for (txid, petition_tx) in petitions.txid_to_petition.borrow().iter() {
            println!("\ttxid={:?}", txid);
            for (entity_address, petition_entity) in petition_tx.for_entities.borrow().iter() {
                println!("\t\tentity={:?}", entity_address);
                for factor in petition_entity.all_factor_instances() {
                    println!("\t\t\tfactor={:#?}", factor);
                }
            }
        }
    }
}
```